### PR TITLE
Clusternaming

### DIFF
--- a/doc/server_config.md
+++ b/doc/server_config.md
@@ -6,12 +6,12 @@ If you want to do more than just displaying static CSV files, you need to config
 
 Make sure you have the following packages installed:
 
-* PHP 5.3+ with the following extensions: 
+* PHP 5.3+ with the following extensions:
   * curl
   * pdo_sqlite
   * mbstring
   * fileinfo
-* R 3.1.3+ (https://www.r-project.org/) with the following libraries. **Make sure you install these packages for all users, so that Apache can load them.**
+* R 3.3+ (https://www.r-project.org/) with the following libraries. **Make sure you install these packages for all users, so that Apache can load them.**
  * GMD
  * MASS
  * ecodist

--- a/doc/server_config.md
+++ b/doc/server_config.md
@@ -11,7 +11,7 @@ Make sure you have the following packages installed:
   * pdo_sqlite
   * mbstring
   * fileinfo
-* R 3.3+ (https://www.r-project.org/) with the following libraries. **Make sure you install these packages for all users, so that Apache can load them.**
+* R 3.3+ (https://www.r-project.org/) with current updates, with the following libraries. **Make sure you install these packages for all users, so that Apache can load them.**
  * GMD
  * MASS
  * ecodist

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -216,7 +216,13 @@ create_cluster_labels <- function(clusters, metadata_full_subjects, weightingspe
   tfidf_top_names <- lapply(tfidf_top_names, function(x) {x = gsub("_", " ", x); trim(x)})
   tfidf_top_names <- lapply(tfidf_top_names, function(x) filter_out_nested_ngrams(x, top_n))
   tfidf_top_names <- lapply(tfidf_top_names, function(x) {paste0(toupper(substr(x, 1, 1)), substr(x, 2, nchar(x)))})
-  clusters$cluster_labels <- lapply(tfidf_top_names, function(x) {paste(unlist(trim(x)), collapse=", ")})
+  tfidf_top_names <- lapply(tfidf_top_names, function(x) {paste(unlist(trim(x)), collapse=", ")})
+  clusters$cluster_labels = ""
+  for (k in seq(1, clusters$num_clusters)) {
+    group = c(names(clusters$groups[clusters$groups == k]))
+    matches = which(clusters$labels%in%group)
+    clusters$cluster_labels[c(matches)] = tfidf_top_names[k]
+  }
   return(clusters)
 }
 
@@ -253,7 +259,7 @@ create_output <- function(clusters, layout, metadata) {
   result = cbind(x,y,groups,labels)
   output = merge(metadata, result, by.x="id", by.y="labels", all=TRUE)
   names(output)[names(output)=="groups"] <- "area_uri"
-  output["area"] = paste("Cluster ", output$area_uri, sep="")
+  output["area"] = cluster_labels
 
   output_json = toJSON(output)
 

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -64,10 +64,6 @@ create_tdm_matrix <- function(metadata, text, sparsity=1, lang="english") {
   return(list(tdm_matrix = tdm_matrix, metadata_full_subjects = metadata_full_subjects))
 }
 
-BigramTokenizer <- function(x) unlist(lapply(ngrams(words(x), 2), paste, collapse = " "), use.names = FALSE)
-
-TrigramTokenizer <- function(x) unlist(lapply(ngrams(words(x), 3), paste, collapse = " "), use.names = FALSE)
-
 replace_keywords_if_empty <- function(corpus, metadata) {
 
   missing_subjects = which(lapply(metadata$subject, function(x) {nchar(x)}) <= 1)

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -19,48 +19,48 @@ vis_layout <- function(text, metadata, max_clusters=15, maxit=500, mindim=2, max
   result <- create_tdm_matrix(metadata, text);
   metadata_full_subjects = result$metadata_full_subjects
   metadata_full_subjects_tfidf_top5 <- create_node_names(metadata_full_subjects)
-  
+
   print("normalize matrix")
   normalized_matrix <- normalize_matrix(result$tdm_matrix);
-  
+
   print("create clusters")
   clusters <- create_clusters(normalized_matrix, max_clusters=15);
   layout <- create_ordination(normalized_matrix, maxit=500, mindim=2, maxdim=2)
   output <- create_output(clusters, layout, metadata_full_subjects)
-  
+
   return(output)
-  
+
 }
 
 create_tdm_matrix <- function(metadata, text, sparsity=1, lang="english") {
   m <- list(content = "content", id = "id")
-  
+
   myReader <- readTabular(mapping = m)
-  
+
   (corpus <- Corpus(DataframeSource(text), readerControl = list(reader = myReader)))
-  
+
   corpus <- tm_map(corpus, removePunctuation)
-  
+
   corpus <- tm_map(corpus, removeWords, stopwords(lang))
-  
+
   corpus <- tm_map(corpus, stripWhitespace)
-  
+
   metadata_full_subjects <- replace_keywords_if_empty(corpus, metadata)
-  
+
   # corpus <- tm_map(corpus, content_transformer(tolower))
-  
+
   corpus_unstemmed = corpus
-  
+
   corpus <- tm_map(corpus, stemDocument)
-  
+
   tdm <- TermDocumentMatrix(corpus)
-  
+
   if(sparsity < 1) {
     tdm <- removeSparseTerms(tdm, sparsity)
   }
-  
+
   tdm_matrix = t(as.matrix(tdm))
-  
+
   return(list(tdm_matrix = tdm_matrix, metadata_full_subjects = metadata_full_subjects))
 }
 
@@ -69,33 +69,33 @@ BigramTokenizer <- function(x) unlist(lapply(ngrams(words(x), 2), paste, collaps
 TrigramTokenizer <- function(x) unlist(lapply(ngrams(words(x), 3), paste, collapse = " "), use.names = FALSE)
 
 replace_keywords_if_empty <- function(corpus, metadata) {
-  
+
   missing_subjects = which(lapply(metadata$subject, function(x) {nchar(x)}) <= 1)
-  
+
   candidates = mapply(paste, metadata$title[missing_subjects], metadata$paper_abstract[missing_subjects])
   candidates = lapply(candidates, function(x)paste(removeWords(x, stopwords('english')), collapse=""))
   candidates = lapply(candidates, function(x)paste(unlist(strsplit(x, split="  ")), collapse=" "))
   candidates_bigrams = lapply(lapply(candidates, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split=" ")), 2), paste, collapse="_"))), paste, collapse=" ")
   candidates = mapply(paste, candidates, candidates_bigrams)
   candidates = lappy(candidates, function(x) {gsub('\\b\\d+\\s','', x)})
-  
+
   nn_corpus <- Corpus(VectorSource(candidates))
   nn_tfidf <- TermDocumentMatrix(nn_corpus, control = list(tokenize = SplitTokenizer, weighting = function(x) weightSMART(x, spec="ntn")))
   tfidf_top <- apply(nn_tfidf, 2, function(x) {x2 <- sort(x, TRUE);x2[x2>=x2[3]]})
   tfidf_top_names <- lapply(tfidf_top, names)
   replacement_keywords <- lapply(tfidf_top_names, FUN = function(x) {paste(unlist(x), collapse="; ")})
   replacement_keywords <- gsub("_", " ", replacement_keywords)
-  
+
   metadata$subject[missing_subjects] <- replacement_keywords
-  
+
   return(metadata)
-  
+
 }
 
 normalize_matrix <- function(tdm_matrix, method = "cosine") {
   distance_matrix_2 <- as.matrix(proxy::dist(tdm_matrix, method))
   distance_matrix = as.dist(distance_matrix_2)
-  
+
   return(distance_matrix)
 }
 
@@ -103,18 +103,18 @@ create_clusters <- function(distance_matrix, max_clusters=-1, method="ward.D") {
   # Perform clustering, use elbow to determine a good number of clusters
   css_cluster <- css.hclust(distance_matrix, hclust.FUN.MoreArgs=list(method="ward.D"))
   cut_off <<- elbow.batch(css_cluster)
-  
+
   num_clusters = cut_off$k
-  
+
   if(max_clusters > -1 && num_clusters > max_clusters) {
     num_clusters = MAX_CLUSTERS
   }
-  
+
   meta_cluster = attr(css_cluster,"meta")
   cluster = meta_cluster$hclust.obj
   labels = labels(distance_matrix)
   groups <- cutree(cluster, k=num_clusters)
-  
+
   if(debug == TRUE) {
     # Plot result of clustering to PDF file
     pdf("clustering.pdf", width=19, height=12)
@@ -122,25 +122,25 @@ create_clusters <- function(distance_matrix, max_clusters=-1, method="ward.D") {
     rect.hclust(cluster, k=num_clusters, border="red")
     dev.off()
   }
-  
+
   clusters = list("labels"=labels, "cluster"=cluster, "groups"=groups, "num_clusters"=num_clusters)
   return(clusters)
-  
+
 }
 
 create_ordination <- function(distance_matrix, mindim=2, maxdim=2, maxit=500) {
-  
+
   # Perform non-metric multidimensional scaling
   nm <<- par.nmds(distance_matrix, mindim=mindim, maxdim=maxdim, maxit=maxit)
   nm.nmin = nmds.min(nm)
-  
+
   if(debug == TRUE) {
     # Plot results from multidimensional scaling, highlight clusters with symbols
     pdf("mds.pdf")
     plot(nm.nmin, pch=groups)
     dev.off()
   }
-  
+
   return(nm.nmin)
 }
 
@@ -150,22 +150,27 @@ SplitTokenizer <- function(x) {
   return(tokens)
 }
 
+
 create_cluster_names <- function(clusters, metadata_full_subjects, weightingspec, top_n) {
   subjectlist = list()
   for (k in seq(1, clusters$num_clusters)) {
     group = c(names(clusters$groups[clusters$groups == k]))
     matches = which(metadata_full_subjects$id%in%group)
+
     titles =  metadata_full_subjects$title[c(matches)]
-    titles = lapply(titles, function(x)paste(removeWords(x, stopwords('english')), collapse=""))
-    titles = lapply(titles, function(x)paste(unlist(strsplit(x, split="  ")), collapse=" "))
+    subjects = metadata_full_subjects$subject[c(matches)]
+    texts = mapply(paste, titles, subjects)
+    texts = lapply(texts, function(x) {gsub("[^[:alnum:]]", " ", x)})
+
+    texts = lapply(texts, function(x)paste(removeWords(x, stopwords('english')), collapse=""))
+    texts = lapply(texts, function(x)paste(unlist(strsplit(x, split="  ")), collapse=" "))
+
     # for ngrams: we have to collapse with "_" or else tokenizers will split ngrams again at that point and we'll be left with unigrams
-    title_bigrams = lapply(lapply(titles, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split=" ")), 2), paste, collapse="_"))), paste, collapse=";")
-    title_trigrams = lapply(lapply(titles, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split=" ")), 3), paste, collapse="_"))), paste, collapse=";")
-    #title_quadgrams = lapply(lapply(titles, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split=" ")), 4), paste, collapse="_"))), paste, collapse=";")
-    subjects = paste(metadata_full_subjects$subject[c(matches)], 
-                     metadata_full_subjects$paper_abstract[c(matches)],
-                     title_bigrams, title_trigrams, 
-                     collapse=";")
+    texts_bigrams = lapply(lapply(texts, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split=" ")), 2), paste, collapse="_"))), paste, collapse=" ")
+    texts_trigrams = lapply(lapply(texts, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split=" ")), 3), paste, collapse="_"))), paste, collapse=" ")
+
+    subjects = paste(metadata_full_subjects$subject[c(matches)], texts_bigrams, texts_trigrams, collapse=" ")
+    subjects = gsub(",", ";", subjects)
     subjectlist = c(subjectlist, subjects)
   }
   nn_corpus <- Corpus(VectorSource(subjectlist))
@@ -174,34 +179,54 @@ create_cluster_names <- function(clusters, metadata_full_subjects, weightingspec
   tfidf_top <- apply(nn_tfidf, 2, function(x) {x2 <- sort(x, TRUE);x2[x2>=x2[3]]})
   tfidf_top_names <- lapply(tfidf_top, names)
   tfidf_top_names <- lapply(tfidf_top_names, function(x) filter_out_nested_ngrams(x, top_n))
+  tfidf_top_names <- lapply(tfidf_top_names, function(x) {gsub("_", " ", x)})
   clusters$cluster_names <- tfidf_top_names
   return(clusters)
 }
 
+filter_out_nested_ngrams <- function(top_ngrams, top_n) {
+  top_names <- list()
+  for (ngram in top_ngrams) {
+    ngram_in_top_names = grepl(ngram, top_names)
+    top_names_with_ngram = sapply(top_names, function(x)(grepl(x, ngram)))
+    # ngram substring of any top_name, and no top_name substring of ngram -> skip ngram
+    if (any(ngram_in_top_names == TRUE) && all(top_names_with_ngram == FALSE)) {}
+    # ngram not substring of any top_name, but at least one top_name is a substring of ngram -> replace top_name with ngram
+    else if (all(ngram_in_top_names == FALSE) && any(top_names_with_ngram == TRUE)) {
+      top_names[which(top_names_with_ngram)] <- ngram
+    }
+    # a not substring of b, b not substring of a -> add b, next
+    else if (all(ngram_in_top_names == FALSE) && all(top_names_with_ngram == FALSE)) {
+      top_names <- unlist(c(top_names, ngram))
+    }
+  }
+  return(head(unique(top_names), top_n))
+}
+
 
 create_output <- function(clusters, layout, metadata) {
-  
+
   x = layout$X1
   y = layout$X2
   labels = clusters$labels
   groups = clusters$groups
   cluster = clusters$cluster
   num_clusters = clusters$num_clusters
-  
+
   # Prepare the output
   result = cbind(x,y,groups,labels)
   output = merge(metadata, result, by.x="id", by.y="labels", all=TRUE)
   names(output)[names(output)=="groups"] <- "area_uri"
   output["area"] = paste("Cluster ", output$area_uri, sep="")
-  
+
   output_json = toJSON(output)
-  
+
   if(debug == TRUE) {
     # Write output to file
     file_handle = file("output_file.csv", open="w")
     write.csv(output, file=file_handle, row.names=FALSE)
     close(file_handle)
-    
+
     # Write some stats to a file
     file_handle = file("stats.txt", open="w")
     writeLines(c(paste("Number of Clusters:", num_clusters, sep=" ")
@@ -209,10 +234,10 @@ create_output <- function(clusters, layout, metadata) {
                  , paste("Stress:", min(nm$stress), sep=" ")
                  , paste("R2:", max(nm$r2), sep=" ")
     ), file_handle)
-    
+
     close(file_handle)
   }
-  
+
   return(output_json)
-  
+
 }

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -182,7 +182,7 @@ trim <- function (x) gsub("^\\s+|\\s+$", "", x)
 
 
 filter_out <- function(ngrams, stops){
-  tokens = mapply(strsplit, ngrams, split=" ")
+  tokens = mapply(strsplit, ngrams, split=" |;")
   tokens = mapply(strsplit, tokens, split="_")
   tokens = lapply(tokens, function(y){
                           Filter(function(x){
@@ -197,6 +197,8 @@ filter_out <- function(ngrams, stops){
                                       !(x[1]==tail(x,1))
                                         }, y)})
   tokens = lapply(tokens, function(y){Filter(function(x){length(x)>1},y)})
+  empties = which(lapply(tokens, length)==0)
+  tokens[c(empties)] = list("")
   tokens = lapply(tokens, function(x){mapply(paste, x, collapse="_")})
   tokens = lapply(tokens, paste, collapse=";")
   return (tokens)

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -180,6 +180,7 @@ create_cluster_names <- function(clusters, metadata_full_subjects, weightingspec
   tfidf_top_names <- lapply(tfidf_top, names)
   tfidf_top_names <- lapply(tfidf_top_names, function(x) filter_out_nested_ngrams(x, top_n))
   tfidf_top_names <- lapply(tfidf_top_names, function(x) {gsub("_", " ", x)})
+  tfidf_top_names <- lapply(tfidf_top_names, function(x) {paste0(toupper(substr(x, 1, 1)), substr(x, 2, nchar(x)))})
   clusters$cluster_names <- tfidf_top_names
   return(clusters)
 }

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -256,10 +256,10 @@ create_output <- function(clusters, layout, metadata) {
   cluster_labels = clusters$cluster_labels
 
   # Prepare the output
-  result = cbind(x,y,groups,labels)
+  result = cbind(x,y,groups,labels, cluster_labels)
   output = merge(metadata, result, by.x="id", by.y="labels", all=TRUE)
   names(output)[names(output)=="groups"] <- "area_uri"
-  output["area"] = cluster_labels
+  output["area"] = output$cluster_labels
 
   output_json = toJSON(output)
 

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -14,9 +14,9 @@ debug = FALSE
 # Expects the following metadata fields:
 # id, content, title, readers, published_in, year, authors, paper_abstract, subject
 
-vis_layout <- function(text, metadata, max_clusters=15, maxit=500, mindim=2, maxdim=2) {
+vis_layout <- function(text, metadata, max_clusters=15, maxit=500, mindim=2, maxdim=2, lang="english") {
   print("calc matrix")
-  result <- create_tdm_matrix(metadata, text);
+  result <- create_tdm_matrix(metadata, text, lang);
   metadata_full_subjects = result$metadata_full_subjects
 
   print("normalize matrix")
@@ -24,7 +24,7 @@ vis_layout <- function(text, metadata, max_clusters=15, maxit=500, mindim=2, max
 
   print("create clusters")
   clusters <- create_clusters(normalized_matrix, max_clusters=15);
-  named_clusters <- create_cluster_labels(clusters, metadata_full_subjects, weightingspec="ntn", top_n=3, lang="english", taxonomy_separator=NULL)
+  named_clusters <- create_cluster_labels(clusters, metadata_full_subjects, weightingspec="ntn", top_n=3, lang=lang, taxonomy_separator=NULL)
   layout <- create_ordination(normalized_matrix, maxit=500, mindim=2, maxdim=2)
   output <- create_output(named_clusters, layout, metadata_full_subjects)
 
@@ -32,7 +32,7 @@ vis_layout <- function(text, metadata, max_clusters=15, maxit=500, mindim=2, max
 
 }
 
-create_tdm_matrix <- function(metadata, text, sparsity=1, lang="english") {
+create_tdm_matrix <- function(metadata, text, lang, sparsity=1) {
   m <- list(content = "content", id = "id")
 
   myReader <- readTabular(mapping = m)

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -175,7 +175,7 @@ create_cluster_names <- function(clusters, metadata_full_subjects, weightingspec
   }
   nn_corpus <- Corpus(VectorSource(subjectlist))
   nn_corpus <- tm_map(nn_corpus, removeWords, stopwords("english"))
-  nn_tfidf <- TermDocumentMatrix(nn_corpus, control = list(tokenize = SplitTokenizer, weighting = function(x) weightSMART(x, spec=weightingspec)))
+  nn_tfidf <- TermDocumentMatrix(nn_corpus, control = list(tokenize = SplitTokenizer, weighting = function(x) weightSMART(x, spec="ntn")))
   tfidf_top <- apply(nn_tfidf, 2, function(x) {x2 <- sort(x, TRUE);x2[x2>=x2[3]]})
   tfidf_top_names <- lapply(tfidf_top, names)
   tfidf_top_names <- lapply(tfidf_top_names, function(x) filter_out_nested_ngrams(x, top_n))

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -259,7 +259,7 @@ create_output <- function(clusters, layout, metadata) {
   result = cbind(x,y,groups,labels, cluster_labels)
   output = merge(metadata, result, by.x="id", by.y="labels", all=TRUE)
   names(output)[names(output)=="groups"] <- "area_uri"
-  output["area"] = output$cluster_labels
+  output["area"] = paste(output$cluster_labels, sep="")
 
   output_json = toJSON(output)
 

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -73,7 +73,7 @@ replace_keywords_if_empty <- function(corpus, metadata) {
   candidates = lapply(candidates, function(x)paste(unlist(strsplit(x, split="  ")), collapse=" "))
   candidates_bigrams = lapply(lapply(candidates, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split=" ")), 2), paste, collapse="_"))), paste, collapse=" ")
   candidates = mapply(paste, candidates, candidates_bigrams)
-  candidates = lappy(candidates, function(x) {gsub('\\b\\d+\\s','', x)})
+  candidates = lapply(candidates, function(x) {gsub('\\b\\d+\\s','', x)})
 
   nn_corpus <- Corpus(VectorSource(candidates))
   nn_tfidf <- TermDocumentMatrix(nn_corpus, control = list(tokenize = SplitTokenizer, weighting = function(x) weightSMART(x, spec="ntn")))


### PR DESCRIPTION
* reworked missing keyword routine: now cleaner and returning better keywords
* added TF-IDF cluster naming based on titles, keywords, and their bi/trigrams
* added cascading filter from longer to shorter ngrams
* formatting gets lost, so included simple first-letter uppercasing
* some old code removed
* tested only locally, result for "natural language processing" on pubmed attached
[natural language processing_pubmed_ntn_clustering.pdf](https://github.com/OpenKnowledgeMaps/Headstart/files/791844/natural.language.processing_pubmed_ntn_clustering.pdf)
