### PR TITLE
[WIP] Replace open access icon with open data icon for datasets

### DIFF
--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -232,8 +232,15 @@ list.populateMetaData = function(nodes) {
 
         list_metadata.select("#open-access-logo_list")
                 .style("display", function (d) {
-                    if (d.oa === false) {
+                    if (d.oa === false || d.doctype === 'dataset') {
                         return "none";
+                    }
+                });
+
+			list_metadata.select("#open-data-logo_list")
+                .style("display", function (d) {
+                    if (d.doctype !== 'dataset') {
+                      return "none";
                     }
                 });
 

--- a/vis/js/papers.js
+++ b/vis/js/papers.js
@@ -151,8 +151,15 @@ papers.drawPapers = function () {
     
     d3.selectAll("#article_metadata").select("#open-access-logo")
             .style("display", function (d) {
-                if(d.oa === false) {
+                if(d.oa === false || d.doctype === 'dataset') {
                     return "none";
+                }
+            });
+
+    d3.selectAll('#article_metadata').select('#open-data-logo')
+            .style('display', function(d) {
+                if (d.doctype !== 'dataset') {
+                    return 'none';
                 }
             });
     

--- a/vis/stylesheets/base/_colors.scss
+++ b/vis/stylesheets/base/_colors.scss
@@ -23,4 +23,5 @@ $author-green: #216500;
 $abstract-gray: #333; //#5c6d7f; //old: #444444
 $journal-gray: #5c6d7f; // old:#666666
 $open-access: $okm-red;
+$open-data: #637ABD;
 $list_show_hide_button_border: $okm-clouds;

--- a/vis/stylesheets/modules/list/_entry.scss
+++ b/vis/stylesheets/modules/list/_entry.scss
@@ -19,6 +19,16 @@
     font-weight: normal;
 }
 
+#open-data-logo_list {
+    background-color: $open-data;
+    color: white;
+    padding: 2px 4px;
+    border-radius: 5px;
+    font-size: 10px;
+    vertical-align: top;
+    font-weight: normal;
+}
+
 .list_metadata {
     /*border-top-width: 2px;
     border-top-style: solid;

--- a/vis/stylesheets/modules/map/_papers.scss
+++ b/vis/stylesheets/modules/map/_papers.scss
@@ -111,11 +111,9 @@
 
 }
 
-
-#open-access-logo {
+#open-access-logo, #open-data-logo {
     font-family: 'FontAwesome';
     display:inline-block;
-    background-color: $open-access;
     color: white;
     padding: 6px 4px;
     font-size: 8px;
@@ -135,6 +133,14 @@
         max-width: initial;
         vertical-align: top;
     }
+}
+
+#open-access-logo {
+    background-color: $open-access;
+}
+
+#open-data-logo {
+    background-color: $open-data;
 }
 
 

--- a/vis/templates/list/list_entry.handlebars
+++ b/vis/templates/list/list_entry.handlebars
@@ -2,7 +2,8 @@
 <div class="list_metadata">
 
     <div class="list_title">
-<span id="open-access-logo_list">open access <span class="outlink_symbol">&#xf09c;</span></span>	
+<span id="open-access-logo_list">open access <span class="outlink_symbol">&#xf09c;</span></span>
+<span id="open-data-logo_list">open data <span class="outlink_symbol">&#xf09c;</span></span>
 <a id="paper_list_title" class="highlightable"></a>
 
 	

--- a/vis/templates/map/paper.handlebars
+++ b/vis/templates/map/paper.handlebars
@@ -3,6 +3,7 @@
     <div class="metadata" style="height:{{{ metadata_height }}}px; width:{{{ metadata_width }}}px;">
         <div id="icons">    
            <p id="open-access-logo">&#xf09c;</p>
+           <p id="open-data-logo">&#xf09c;</p>
            <!--<p id="outlink" ><a href="{{{ d.oa_link }}}" target="_blank" class="outlink_symbol">&nbsp;&#xf019;</a></p>
            <p id="outlink"><a href="{{{ d.outlink }}}" target="_blank"><span class="outlink_symbol">&nbsp;&#xf08e;</span></a></p>
 -->


### PR DESCRIPTION
WIP.

Paper open data icon:

<img width="607" alt="screen shot 2017-11-21 at 11 54 21" src="https://user-images.githubusercontent.com/424411/33071260-b9b1f336-ceb2-11e7-8e25-8cc219fe2055.png">

TODO:

- [ ] Replace icon in sidebar list 
