### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/server/preprocessing/other-scripts/rplos.R
+++ b/server/preprocessing/other-scripts/rplos.R
@@ -49,7 +49,7 @@ names(cooc)[names(cooc)=="abstract"] <- "paper_abstract"
 names(cooc)[names(cooc)=="journal"] <- "published_in"
 names(cooc)[names(cooc)=="publication_date"] <- "year"
 names(cooc)[names(cooc)=="author"] <- "authors"
-cooc["url"] = paste("http://dx.doi.org/", cooc$id, sep="")
+cooc["url"] = paste("https://doi.org/", cooc$id, sep="")
 cooc["titleabstract"] = paste(cooc$title, cooc$abstract, sep=" ")
 dates = as.Date(cooc$year)
 cooc$year = format(dates, format="%B %d %Y")

--- a/server/preprocessing/other-scripts/rplos_fast.R
+++ b/server/preprocessing/other-scripts/rplos_fast.R
@@ -48,7 +48,7 @@ get_papers <- function(query, params, limit=100, fields="title,id,counter_total_
   names(metadata)[names(metadata)=="journal"] <- "published_in"
   names(metadata)[names(metadata)=="publication_date"] <- "year"
   names(metadata)[names(metadata)=="author"] <- "authors"
-  metadata["url"] = paste("http://dx.doi.org/", metadata$id, sep="")
+  metadata["url"] = paste("https://doi.org/", metadata$id, sep="")
   dates = as.Date(metadata$year)
   metadata$year = format(dates, format="%B %d %Y")
   metadata$subject_orig = metadata$subject


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by changing all static DOI links, as well as code that generates new ones.

Cheers :-)