### PR TITLE
VIPER metrics

### DIFF
--- a/doc/server_config.md
+++ b/doc/server_config.md
@@ -36,8 +36,6 @@ Make sure you have the following packages installed:
   * rcrossref (for VIPER)
   * rAltmetric
   * plyr (for better data munging)
-  * magrittr
-  * purrr
 * phantomjs 2.1+ (http://phantomjs.org/), if you want to use the snapshot feature
 
 ## Configuration

--- a/doc/server_config.md
+++ b/doc/server_config.md
@@ -34,7 +34,10 @@ Make sure you have the following packages installed:
   * ropenaire (For VIPER. Currently, a Github repository only: https://github.com/sckott/ropenaire. Install with devtools.)
   * readr (for ropenair/VIPER)
   * rcrossref (for VIPER)
+  * rAltmetric
   * plyr (for better data munging)
+  * magrittr
+  * purrr
 * phantomjs 2.1+ (http://phantomjs.org/), if you want to use the snapshot feature
 
 ## Configuration

--- a/doc/server_config.md
+++ b/doc/server_config.md
@@ -32,7 +32,8 @@ Make sure you have the following packages installed:
   * jaod (Currently, a Github repository only: http://github.com/ropenscilabs/jaod. Install with  devtools.)
   * rbace (Currently, a Github repository only: http://github.com/ropenscilabs/rbace. Install with devtools.)
   * ropenaire (For VIPER. Currently, a Github repository only: https://github.com/sckott/ropenaire. Install with devtools.)
-  * readr (for ropenair/VIPER only)
+  * readr (for ropenair/VIPER)
+  * rcrossref (for VIPER)
   * plyr (for better data munging)
 * phantomjs 2.1+ (http://phantomjs.org/), if you want to use the snapshot feature
 

--- a/server/preprocessing/other-scripts/altmetrics.R
+++ b/server/preprocessing/other-scripts/altmetrics.R
@@ -1,9 +1,12 @@
 library('rAltmetric')
+library('rcrossref')
 
-enrich_input <- function(input_data){
-  dois <- input_data$metadata$doi
-  results <- get_altmetrics(dois)
-  input_data$metadata <- merge(input_data$metadata, results, by='doi', all=TRUE)
+enrich_output <- function(output){
+  results <- get_altmetrics(output$doi)
+  results <- results[c('doi', 'cited_by_tweeters_count', 'readers.mendeley')]
+  output <- merge(output, results, by='doi', all=TRUE)
+  output <- add_citations(output)
+  return (output)
 }
 
 get_altmetrics <- function(dois){
@@ -19,4 +22,12 @@ get_altmetrics <- function(dois){
     })
   }
   return (results)
+}
+
+add_citations <- function(output){
+  dois <- output$doi
+  valid_dois <- which(dois!="")
+  cit_count <- check_metadata(unlist(lapply(dois[valid_dois], function(x) cr_citation_count(doi=x))))
+  output$citation_count[c(valid_dois)] <- cit_count
+  return (output)
 }

--- a/server/preprocessing/other-scripts/altmetrics.R
+++ b/server/preprocessing/other-scripts/altmetrics.R
@@ -1,0 +1,24 @@
+library(rAltmetric)
+library(magrittr)
+library(purrr)
+
+enrich_input <- function(input_data){
+  dois <- input_data$metadata$doi
+  results <- get_altmetrics(dois)
+  input_data$metadata <- merge(input_data$metadata, results, by='doi', all=TRUE)
+}
+
+get_altmetrics <- function(dois){
+  valid_dois <- which(dois!="")
+  ids <- list(c(dois[valid_dois]))
+  results <- data.frame()
+  for (doi in dois[valid_dois]){
+    tryCatch({
+      metrics <- altmetric_data(altmetrics(doi=doi))
+      results <- rbind.fill(results, metrics)
+    }, error = function(err){
+      print(paste(err, doi))
+    })
+  }
+  return (results)
+}

--- a/server/preprocessing/other-scripts/altmetrics.R
+++ b/server/preprocessing/other-scripts/altmetrics.R
@@ -1,6 +1,4 @@
-library(rAltmetric)
-library(magrittr)
-library(purrr)
+library('rAltmetric')
 
 enrich_input <- function(input_data){
   dois <- input_data$metadata$doi

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -111,11 +111,3 @@ get_papers <- function(query, params, limit=100, fields="title,id,counter_total_
   return(ret_val)
 
 }
-
-check_metadata <- function (field) {
-  if(!is.null(field)) {
-    return (ifelse(is.na(field), '', field))
-  } else {
-    return ('')
-  }
-}

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -134,6 +134,7 @@ parse_response <- function(response) {
   if (!(length(tmp) == 0)) {
     df <- data.frame(data.table::rbindlist(tmp, fill = TRUE, use.names = TRUE))
     df$id <- unlist(lapply(xml_find_all(response, ".//dri:objIdentifier"), xml_text))
+    df$year <- unlist(lapply(df$year, function(x){substr(x, 0, 4)}))
     return (df)
   } else {
     stop("Length of results: ", length(tmp))

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -153,7 +153,7 @@ get_doi <- function(title) {
 fill_dois <- function(df) {
   missing_doi_indices <- which(df$doi == "")
   titles <- df[missing_doi_indices,]$title
-  df[missing_doi_indices,]$doi <- lapply(titles, get_doi)
+  df$doi[c(missing_doi_indices)] <- unlist(lapply(titles, get_doi))
   return (df)
 }
 

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -30,7 +30,6 @@ get_papers <- function(query, params, limit=NULL) {
   # parse params
   project_id <- params$project_id
   funding_level <- params$funding_level
-  project_id <- "911723"
 
   # identify search on projects
   # project <- roa_projects(acronym = query)
@@ -81,15 +80,14 @@ get_papers <- function(query, params, limit=NULL) {
     get_return_values(all_artifacts)
     }, error = function(err){
       print(err)
-      print(paste("Empty returns, most likely no results found for project_id", project_id))
-      return (NULL)
+      stop(paste("Empty returns, most likely no results found for project_id", project_id))
     })
 }
 
 get_return_values <- function(all_artifacts){
   # crude filling
   all_artifacts[is.na(all_artifacts)] <- ""
-  
+
   text = data.frame(matrix(nrow=nrow(all_artifacts)))
   text$id = all_artifacts$id
   # paste whats available and makes sense
@@ -130,8 +128,7 @@ parse_response <- function(response) {
     df$id <- unlist(lapply(xml_find_all(response, ".//dri:objIdentifier"), xml_text))
     return (df)
   } else {
-    print("No results found")
-    return (NULL)
+    stop("Length of results: ", length(tmp))
   }
 }
 

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -34,7 +34,7 @@ get_papers <- function(query, params, limit=NULL) {
   # identify search on projects
   # project <- roa_projects(acronym = query)
   # project_id <- project$grantID
-  # funding_stream <- tolower(project$funding_stream_0)
+  # funding_stream <- tolower(project$funding_level_0)
 
   # currently not used
   # if funding_stream not as expected, default to fp7

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -74,6 +74,14 @@ get_papers <- function(query, params, limit=NULL) {
       all_artifacts <- rbind.fill(pubs_metadata, datasets_metadata)
     }, error = function(err){
       print(err)
+    }, finally = {
+      if (nrow(pubs_metadata) > 0) {
+        all_artifacts <- pubs_metadata
+      } else if (nrow(datasets_metadata) > 0){
+        all_artifacts <- datasets_metadata
+      } else {
+        all_artifacts <- data.frame(matrix(nrow=1))
+      }
     })
 
   tryCatch({

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -120,13 +120,13 @@ fields <- c(
   journal = ".//journal",
   url = ".//fulltext",
   paper_abstract = ".//description",
-  doi = ".//pid[@schemeid=\"doi\"]",
+  doi = ".//pid[@classid=\"doi\"]",
   id = ".//result[@objidentifier]"
 )
 
 parse_response <- function(response) {
   results <- xml_find_all(response, "//results/result")
-  tmp <- lapply (results, function(result){
+  tmp <- lapply(results, function(result){
     lapply(fields, function(field){
       xml_text(xml_find_first(result, field))
     })

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -182,10 +182,3 @@ queries <- function(titles){
   return (queries)
 }
 
-check_metadata <- function (field) {
-  if(!is.null(field)) {
-    return (ifelse(is.na(field), '', field))
-  } else {
-    return ('')
-  }
-}

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -156,7 +156,7 @@ fill_dois <- function(df) {
     dois <- mapply(check_distance, titles, candidates, USE.NAMES=FALSE)
   } else {
     response <- cr_works(flq=c('query.title'=titles))$data
-    doi <- check_distance(titles, response[1,])
+    dois <- check_distance(titles, response[1,])
   }
   df$doi[c(missing_doi_indices)] <- dois
   return (df)

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -135,7 +135,6 @@ parse_response <- function(response) {
   if (!(length(tmp) == 0)) {
     df <- data.frame(data.table::rbindlist(tmp, fill = TRUE, use.names = TRUE))
     df$id <- unlist(lapply(xml_find_all(response, ".//dri:objIdentifier"), xml_text))
-    df$year <- unlist(lapply(df$year, function(x){substr(x, 0, 4)}))
     return (df)
   } else {
     stop("Length of results: ", length(tmp))

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -8,7 +8,7 @@ library(rcrossref)
 # Params:
 #
 # * query: project acronym
-# * params: parameters for the search in JSON format: funding_stream and funding stream
+# * params: parameters for the search in JSON format: project_id and funding stream
 # * limit: number of search results to return
 #
 # It is expected that get_papers returns a list containing two data frames named "text" and "metadata"
@@ -152,9 +152,14 @@ fill_dois <- function(df) {
     print("Time for filling missing DOIs")
     print(system.time(cr_works(query=queries(titles), async=TRUE)))
   }
-  response <- cr_works(query=queries(titles), async=TRUE)
-  candidates <- lapply(response, function(x){x[1,c('DOI', 'title')]})
-  dois <- mapply(check_distance, titles, candidates, USE.NAMES=FALSE)
+  if (length(titles) > 1) {
+    response <- cr_works(query=queries(titles), async=TRUE)
+    candidates <- lapply(response, function(x){x[1,c('DOI', 'title')]})
+    dois <- mapply(check_distance, titles, candidates, USE.NAMES=FALSE)
+  } else {
+    response <- cr_works(flq=c('query.title'=titles))$data
+    doi <- check_distance(titles, response[1,])
+  }
   df$doi[c(missing_doi_indices)] <- dois
   return (df)
 }

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -154,9 +154,11 @@ fill_dois <- function(df) {
     response <- cr_works(query=queries(titles), async=TRUE)
     candidates <- lapply(response, function(x){x[1,c('DOI', 'title')]})
     dois <- mapply(check_distance, titles, candidates, USE.NAMES=FALSE)
-  } else {
+  } else if (length(titles) == 1) {
     response <- cr_works(flq=c('query.title'=titles))$data
     dois <- check_distance(titles, response[1,])
+  } else {
+    dois <- ""
   }
   df$doi[c(missing_doi_indices)] <- dois
   return (df)

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -26,8 +26,6 @@ library(rcrossref)
 # * "readers": an indicator of the paper's popularity, e.g. number of readers, views, downloads etc.
 # * "subject": keywords or classification, split by ;
 
-DEBUG <- TRUE
-
 get_papers <- function(query, params, limit=NULL) {
   # parse params
   project_id <- params$project_id
@@ -147,7 +145,7 @@ parse_response <- function(response) {
 fill_dois <- function(df) {
   missing_doi_indices <- which(is.na(df$doi))
   titles <- df[missing_doi_indices,]$title
-  if (DEBUG) {
+  if (debug) {
     print(paste("Missing DOIs:", length(titles)))
     print("Time for filling missing DOIs")
     print(system.time(cr_works(query=queries(titles), async=TRUE)))

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -164,8 +164,8 @@ fill_dois <- function(df) {
 }
 
 check_distance <- function(title, candidate) {
-  sdist <- stringdist(title, candidate$title)
-  if (sdist <= 5){
+  lv_ratio <- levenshtein_ratio(tolower(title), tolower(candidate$title))
+  if (lv_ratio <= 1/15.83){
     doi <- candidate$DOI
   } else {
     doi <- ""

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -7,7 +7,7 @@ library(xml2)
 # Params:
 #
 # * query: project acronym
-# * params: parameters for the search in JSON format: funding_level and funding stream
+# * params: parameters for the search in JSON format: funding_stream and funding stream
 # * limit: number of search results to return
 #
 # It is expected that get_papers returns a list containing two data frames named "text" and "metadata"
@@ -29,21 +29,21 @@ library(xml2)
 get_papers <- function(query, params, limit=NULL) {
   # parse params
   project_id <- params$project_id
-  funding_level <- params$funding_level
+  funding_stream <- params$funding_stream
 
   # identify search on projects
   # project <- roa_projects(acronym = query)
   # project_id <- project$grantID
-  # funding_level <- tolower(project$funding_level_0)
+  # funding_stream <- tolower(project$funding_stream_0)
 
   # currently not used
-  # if funding_level not as expected, default to fp7
-  # if (!(funding_level %in% c('fp7', 'h2020'))){
-  #   funding_level <- 'fp7'
+  # if funding_stream not as expected, default to fp7
+  # if (!(funding_stream %in% c('fp7', 'h2020'))){
+  #   funding_stream <- 'fp7'
   # }
   # run searches for publications and data
   # switch according to detected funding stream
-  # switch(funding_level,
+  # switch(funding_stream,
   #   fp7 = {
   #     pubs <- roa_pubs(fp7 = project_id, format = 'json')
   #     datasets <- roa_datasets(fp7 = project_id, format = 'json')

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -4,7 +4,7 @@ library(rstudioapi)
 
 options(warn=1)
 
-wd <- dirname(rstudioapi::getActiveDocumentContext()$path) 
+wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
 
 setwd(wd) #Don't forget to set your working directory
 
@@ -15,6 +15,7 @@ params_file <- "params_base.json"
 
 source("../vis_layout.R")
 source('../base.R')
+source('../utils.R')
 
 debug = FALSE
 
@@ -33,7 +34,7 @@ input_data = get_papers(query, params, limit=120)
 #time.taken <- end.time - start.time
 #time.taken
 
-output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS, 
+output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/doaj-test.R
+++ b/server/preprocessing/other-scripts/test/doaj-test.R
@@ -4,7 +4,7 @@ library(rstudioapi)
 
 options(warn=1)
 
-wd <- dirname(rstudioapi::getActiveDocumentContext()$path) 
+wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
 
 setwd(wd) #Don't forget to set your working directory
 
@@ -15,6 +15,7 @@ params_file <- "params_doaj.json"
 
 source("../vis_layout.R")
 source('../doaj.R')
+source('../utils.R')
 
 debug = FALSE
 

--- a/server/preprocessing/other-scripts/test/pubmed-test.R
+++ b/server/preprocessing/other-scripts/test/pubmed-test.R
@@ -4,7 +4,7 @@ library(rstudioapi)
 
 options(warn=1)
 
-wd <- dirname(rstudioapi::getActiveDocumentContext()$path) 
+wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
 
 setwd(wd) #Don't forget to set your working directory
 
@@ -15,6 +15,7 @@ params_file <- "params_pubmed.json"
 
 source("../vis_layout.R")
 source('../pubmed.R')
+source('../utils.R')
 
 debug = FALSE
 

--- a/server/preprocessing/other-scripts/test/rplos_fast-test.R
+++ b/server/preprocessing/other-scripts/test/rplos_fast-test.R
@@ -12,13 +12,14 @@ params_file <- singleString <- paste(readLines("params.json"), collapse=" ")
 
 
 source("../vis_layout.R")
+source('../utils.R')
 
-switch(service, 
+switch(service,
        plos={
          source("../rplos_fast.R")
        },
        pubmed={
-         source('../pubmed.R')    
+         source('../pubmed.R')
        },
     {
       source("../rplos_fast.R")

--- a/server/preprocessing/other-scripts/test/test-openaire.R
+++ b/server/preprocessing/other-scripts/test/test-openaire.R
@@ -17,6 +17,7 @@ params_file <- "params_openaire.json"
 
 source("../vis_layout.R")
 source('../openaire.R')
+source('../altmetrics.R')
 
 debug = FALSE
 

--- a/server/preprocessing/other-scripts/test/test-openaire.R
+++ b/server/preprocessing/other-scripts/test/test-openaire.R
@@ -18,6 +18,7 @@ params_file <- "params_openaire.json"
 source("../vis_layout.R")
 source('../openaire.R')
 source('../altmetrics.R')
+source('utils.R')
 
 debug = FALSE
 

--- a/server/preprocessing/other-scripts/test/test-openaire.R
+++ b/server/preprocessing/other-scripts/test/test-openaire.R
@@ -18,7 +18,7 @@ params_file <- "params_openaire.json"
 source("../vis_layout.R")
 source('../openaire.R')
 source('../altmetrics.R')
-source('utils.R')
+source('../utils.R')
 
 debug = FALSE
 

--- a/server/preprocessing/other-scripts/text_similarity.R
+++ b/server/preprocessing/other-scripts/text_similarity.R
@@ -14,6 +14,7 @@ print(params_file)
 setwd(wd) #Don't forget to set your working directory
 
 source(paste("../other-scripts/vis_layout.R", sep=""))
+source('../other-scripts/altmetrics.R')
 source('../other-scripts/utils.R')
 
 taxonomy_separator = NULL

--- a/server/preprocessing/other-scripts/text_similarity.R
+++ b/server/preprocessing/other-scripts/text_similarity.R
@@ -14,6 +14,7 @@ print(params_file)
 setwd(wd) #Don't forget to set your working directory
 
 source(paste("../other-scripts/vis_layout.R", sep=""))
+source('../other-scripts/utils.R')
 
 taxonomy_separator = NULL
 limit = 100
@@ -36,7 +37,7 @@ switch(service,
        },
        openaire={
          source('../other-scripts/openaire.R')
-       }
+       },
       {
         source("../other-scripts/rplos_fast.R")
       }

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -1,0 +1,7 @@
+library(stringdist)
+
+levenshtein_ratio <- function(a, b) {
+  lv_dist = stringdist(a, b, method = "lv")
+  lv_ratio = lv_dist/(max(stri_length(a), stri_length(b)))
+  return(lv_ratio)
+}

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -5,3 +5,11 @@ levenshtein_ratio <- function(a, b) {
   lv_ratio = lv_dist/(max(stri_length(a), stri_length(b)))
   return(lv_ratio)
 }
+
+check_metadata <- function (field) {
+  if(!is.null(field)) {
+    return (ifelse(is.na(field), '', field))
+  } else {
+    return ('')
+  }
+}

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -405,9 +405,3 @@ create_output <- function(clusters, layout, metadata) {
   return(output_json)
 
 }
-
-levenshtein_ratio <- function(a, b) {
-  lv_dist = stringdist(a, b, method = "lv")
-  lv_ratio = lv_dist/(max(stri_length(a), stri_length(b)))
-  return(lv_ratio)
-}

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -380,6 +380,7 @@ create_output <- function(clusters, layout, metadata) {
   # Prepare the output
   result = cbind(x,y,groups,labels, cluster_labels)
   output = merge(metadata, result, by.x="id", by.y="labels", all=TRUE)
+  output = enrich_output(output)
   names(output)[names(output)=="groups"] <- "area_uri"
   output["area"] = paste(output$cluster_labels, sep="")
 


### PR DESCRIPTION
* some package restructuring: reused utility functions moved into utils.R
* added altmetrics through integration of rAltmetric as far as available
* note: doi-updates #207 already merged into this PR
* metrics have been added to the output_json under following keys: 'cited_by_tweeters_count', 'readers.mendeley', 'citation_count'

inspect by running test-openaire.R and then
```
output <- fromJSON(output_json)
output[c('title', 'doi', 'cited_by_tweeters_count', 'readers.mendeley', 'citation_count')]
1 - colSums(mapply(is.na, output[c('cited_by_tweeters_count', 'readers.mendeley', 'citation_count')]))/nrow(output)
```
for exemplary data and basic statistics on coverage