### PR TITLE
Update OpenAire service parameters to fit with backend

### DIFF
--- a/server/services/searchOpenAire.php
+++ b/server/services/searchOpenAire.php
@@ -7,11 +7,22 @@ require 'search.php';
 
 use headstart\library;
 
-$acronym = library\CommUtils::getParameter($_POST, "q");
+$acronym = library\CommUtils::getParameter($_POST, "acronym");
 
 $post_params = $_POST;
 
-$result = search("openaire", $acronym, $post_params, array("project_id", "funding_level"), ";", null);
+$result = search("openaire", $acronym, $post_params, array("project_id",
+                                                        "funder",
+                                                        "title",
+                                                        "funding_tree",
+                                                        "call_id",
+                                                        "start_date",
+                                                        "end_date",
+                                                        "oa_mandate",
+                                                        "special_clause",
+                                                        "organisations",
+                                                        "openaire_link"),
+            ";", null);
 
 echo $result
 


### PR DESCRIPTION
* Change q to acronym for clarity
* Change funding_level to funder in order to correspond with R scripts
* Add all project details required to populate 'more info' in headstart

Depended on by: #215 and #217