### PR TITLE
Make link and edit modal buttons clickable in zoomed mode

### DIFF
--- a/vis/stylesheets/modules/map/_header.scss
+++ b/vis/stylesheets/modules/map/_header.scss
@@ -23,7 +23,11 @@
     font-weight: 800;
 }
 
- 
+#modals {
+    position: relative;
+    z-index: 3;
+}
+
 #context {
     font-size: 11px;
     color: $black;


### PR DESCRIPTION
Set the modals div style to have a relative position and
z-index: 3 so it floats above the map and is still clickable when zoomed
in.

This is consistent with the fix for subdiscipline_title introduced by
ba441853