### PR TITLE
Hide unused context elements

### DIFF
--- a/vis/js/canvas.js
+++ b/vis/js/canvas.js
@@ -412,6 +412,8 @@ class Canvas {
                             dateFormat(from, time_macro_display) + " - " + dateFormat(to, time_macro_display)
                     );
                 }
+            } else {
+                $("#timespan").hide()
             }
 
             if(this.paramExists(config.options)) {
@@ -449,6 +451,8 @@ class Canvas {
                         $("#document_types").html("Document type: " + document_types_string);
                     }
                 }
+            } else {
+                $("#document_types").hide()
             }
         } else {
             $("#num_articles").html(context.num_documents)


### PR DESCRIPTION
To stop some odd margins appearing that we don't want hide them
with .hide() if the config variables they are set from in canvas.js
are false