### PR TITLE
Hide dataset icons on papers on map when not a dataset

### DIFF
--- a/vis/js/papers.js
+++ b/vis/js/papers.js
@@ -171,7 +171,7 @@ papers.drawPapers = function () {
             }
         });
 
-    article_metadata.select("#dataset-icon_paper")
+    article_metadata.select("#dataset-icon")
         .style("display", function (d) {
             if (d.resulttype !== "dataset") {
                 return "none"

--- a/vis/templates/map/paper.handlebars
+++ b/vis/templates/map/paper.handlebars
@@ -4,13 +4,8 @@
         <div id="icons">    
            <p id="open-access-logo">&#xf09c;</p>
             <p id="dataset-icon"><span id="dataset-icon_list" class="fa fa-database"></span></p> 
-           <!--<p id="outlink" ><a href="{{{ d.oa_link }}}" target="_blank" class="outlink_symbol">&nbsp;&#xf019;</a></p>
-           <p id="outlink"><a href="{{{ d.outlink }}}" target="_blank"><span class="outlink_symbol">&nbsp;&#xf08e;</span></a></p>
--->
         </div>
     <p id="title" class="highlightable">
-    <!--<span id="dataset-icon_paper" class="fa fa-database"></span>-->
-    <!--<span id="file-icon_paper" class="fa fa-file-text"></span>-->
     {{{ d.title }}}<br /></p>
         <p id="details" class="highlightable">{{{ d.authors_string }}}</p>
         <p id="in">in <span class="highlightable">{{{ d.published_in }}} <span class="pubyear">({{{ d.year }}})</span></span></p>


### PR DESCRIPTION
Short fix to now hide correct element after new id implemented for rounded border for dataset implemented.

Also: Refactor to remove commented code from template to improve clarity
