### PR TITLE
 Sort with dropdown not buttons

### DIFF
--- a/examples/viper/data-config_openaire.js
+++ b/examples/viper/data-config_openaire.js
@@ -14,7 +14,7 @@ var data_config = {
     show_timeline: false,
     show_dropdown: false,
     preview_type: "pdf",
-    sort_options: ["title", "authors", "year"],
+    sort_options: ["authors", "title", "citations", "year"],
     sort_menu_dropdown: true,
     is_force_areas: true,
     language: "eng_openaire",

--- a/examples/viper/data-config_openaire.js
+++ b/examples/viper/data-config_openaire.js
@@ -15,6 +15,7 @@ var data_config = {
     show_dropdown: false,
     preview_type: "pdf",
     sort_options: ["title", "authors", "year"],
+    sort_menu_dropdown: true,
     is_force_areas: true,
     language: "eng_openaire",
     area_force_alpha: 0.015,

--- a/vis/js/default-config.js
+++ b/vis/js/default-config.js
@@ -131,7 +131,8 @@ var config = {
             default_url: "",
             default_x: 1.,
             default_y: 1.,
-            default_year: ""
+            default_year: "",
+            sort_by_label: 'sort by:',
         },
         ger: {
             loading: "Wird geladen...",
@@ -192,7 +193,8 @@ var config = {
             default_url: "",
             default_x: 1.,
             default_y: 1.,
-            default_year: ""
+            default_year: "",
+            sort_by_label: 'sort by:',
         },
         eng_pubmed: {
             loading: "Loading...",
@@ -223,7 +225,8 @@ var config = {
             default_url: "",
             default_x: 1.,
             default_y: 1.,
-            default_year: ""
+            default_year: "",
+            sort_by_label: 'sort by:',
         },
         eng_openaire: {
             loading: "Loading...",
@@ -267,6 +270,7 @@ var config = {
             viper_embed_button_text: 'Copy',
             viper_embed_title: 'embed map',
             sort_by_label: 'sort by:',
+            scale_by_label: 'Scale map by:',
         }
     },
 

--- a/vis/js/default-config.js
+++ b/vis/js/default-config.js
@@ -238,6 +238,7 @@ var config = {
             readers: "citations",
             year: "year",
             authors: "authors",
+            citations: "citations",
             title: "title",
             area: "Area",
             keywords: "Keywords",

--- a/vis/js/default-config.js
+++ b/vis/js/default-config.js
@@ -75,6 +75,7 @@ var config = {
     create_title_from_context: false,
 
     sort_options: ["readers", "title", "authors", "year"],
+    sort_menu_dropdown: false,
 
     content_based: false,
 
@@ -265,6 +266,7 @@ var config = {
             viper_edit_button_text: 'continue to openaire',
             viper_embed_button_text: 'Copy',
             viper_embed_title: 'embed map',
+            sort_by_label: 'sort by:',
         }
     },
 

--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -172,6 +172,10 @@ let addSortOptionDropdownEntry = function(sort_option) {
         mediator.publish("record_action", "none", "sortBy",
             config.user_id, "listsort", null, "sort_option=" + sort_option)
         $('#curr-sort-type').text(config.localization[config.language][sort_option])
+        d3.selectAll('.sort_radio').attr('class', 'sort_radio fa fa-circle-o')
+        newEntry.find('.sort_radio')
+        .removeClass('fa-circle-o')
+        .addClass('fa-circle')
     })
 }
 

--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -124,6 +124,7 @@ list.drawList = function() {
             }
         }
     } else {
+        $('#curr-sort-type').text(config.localization[config.language][config.sort_options[0]])
         for(var i=0; i<numberOfOptions; i++) {
             addSortOptionDropdownEntry(config.sort_options[i])
         }
@@ -163,7 +164,7 @@ list.fit_list_height = function() {
 let addSortOptionDropdownEntry = function(sort_option) {
     let entry = sortDropdownEntryTemplate({
         sort_by_string: config.localization[config.language].sort_by_label,
-        sorter_label: config.localization[config.language][sort_option]
+        sorter_label: config.localization[config.language][sort_option],
     })
     var newEntry = $(entry).appendTo('#sort-menu-entries')
     newEntry.on("click", () => {

--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -87,7 +87,8 @@ list.drawList = function() {
     // Load list template
     let list_explorer = listTemplate({
         show_list: config.localization[config.language].show_list,
-        dropdown: config.sort_menu_dropdown
+        dropdown: config.sort_menu_dropdown,
+        sort_by_label: config.localization[config.language].sort_by_label,
     });
     $("#list_explorer").append(list_explorer);
 

--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -19,6 +19,7 @@ import {
 const listTemplate = require('templates/list/list_explorer.handlebars');
 const selectButtonTemplate = require('templates/list/select_button.handlebars');
 const listEntryTemplate = require("templates/list/list_entry.handlebars");
+const sortDropdownEntryTemplate = require("templates/list/sort_dropdown_entry.handlebars");
 
 export const list = StateMachine.create({
 
@@ -85,7 +86,8 @@ export const list = StateMachine.create({
 list.drawList = function() {
     // Load list template
     let list_explorer = listTemplate({
-        show_list: config.localization[config.language].show_list
+        show_list: config.localization[config.language].show_list,
+        dropdown: config.sort_menu_dropdown
     });
     $("#list_explorer").append(list_explorer);
 
@@ -107,16 +109,22 @@ list.drawList = function() {
         debounce(this.filterList([""]), config.debounce);
     });
 
-    // Add sort options
+    // Add sort button options
     var container = d3.select("#sort_container>ul");
-    var first_element = true;
     const numberOfOptions = config.sort_options.length;
-    for (var i = 0; i < numberOfOptions; i++) {
-        if (first_element) {
-            addSortOption(container, config.sort_options[i], true);
-            first_element = false;
-        } else {
-            addSortOption(container, config.sort_options[i], false);
+    if(!config.sort_menu_dropdown) {
+        var first_element = true;
+        for (var i = 0; i < numberOfOptions; i++) {
+            if (first_element) {
+                addSortOptionButton(container, config.sort_options[i], true);
+                first_element = false;
+            } else {
+                addSortOptionButton(container, config.sort_options[i], false);
+            }
+        }
+    } else {
+        for(var i=0; i<numberOfOptions; i++) {
+            addSortOptionDropdownEntry(config.sort_options[i])
         }
     }
 
@@ -151,7 +159,21 @@ list.fit_list_height = function() {
     $("#papers_list").height(paper_list_avail_height);
 };
 
-let addSortOption = function(parent, sort_option, selected) {
+let addSortOptionDropdownEntry = function(sort_option) {
+    let entry = sortDropdownEntryTemplate({
+        sort_by_string: config.localization[config.language].sort_by_label,
+        sorter_label: config.localization[config.language][sort_option]
+    })
+    var newEntry = $(entry).appendTo('#sort-menu-entries')
+    newEntry.on("click", () => {
+        sortBy(sort_option)
+        mediator.publish("record_action", "none", "sortBy",
+            config.user_id, "listsort", null, "sort_option=" + sort_option)
+        $('#curr-sort-type').text(config.localization[config.language][sort_option])
+    })
+}
+
+let addSortOptionButton = function(parent, sort_option, selected) {
 
     let checked_val = "";
     let active_val = "";

--- a/vis/js/mediator.js
+++ b/vis/js/mediator.js
@@ -284,7 +284,9 @@ MyMediator.prototype = {
         this.viz.append(embedTemplate());
         
         if (config.scale_types.length > 0) {
-            this.viz.append(scaleToolbarTemplate());
+            this.viz.append(scaleToolbarTemplate({
+                scale_by_label: config.localization[config.language].scale_by_label
+            }));
         }
         
         if (!config.render_bubbles) {

--- a/vis/templates/list/list_explorer.handlebars
+++ b/vis/templates/list/list_explorer.handlebars
@@ -11,19 +11,26 @@
         <div id="explorer_options" class="row">
             <div class="" id="filter_container">
                 <div class="input-group input-group-sm">
-{{!--                     <div class="input-group-addon input-sm">
-                      <span class="glyphicon glyphicon-search"></span>
-                    </div> --}}
                     <input id="filter_input" type="text" class="form-control">
                     <span id="searchclear" class="glyphicon glyphicon-remove-circle"></span>
                 </div>
             </div>
 
             <div class="" id="sort_container">
-<span id="sortby">sort by:</span>
-                <div id="sort-buttons" class="btn-group btn-group-sm pull-right" data-toggle="buttons" role="group">
+                {{#if dropdown}}
+                <div class="dropdown">
+                    <button class="btn btn-primary dropdown-toggle" id="sort" type="button" data-toggle="dropdown">
+                        sort by:
+                        <span id="curr-sort-type"></span>
+                        <span class="caret"></span>
+                    </button>
+                    <ul id="sort-menu-entries" class="dropdown-menu" role="menu" aria-labelledby="sort-menu">
+                    </ul>
+                    {{else}}
+                    <span id="sortby">sort by:</span>
+                    <div id="sort-buttons" class="btn-group btn-group-sm pull-right" data-toggle="buttons" role="group"></div>
+                    {{/if}}
                 </div>
             </div>
         </div>
-    </div>
-<div class="col-xs-12" id="papers_list"></div>
+        <div class="col-xs-12" id="papers_list"></div>

--- a/vis/templates/list/list_explorer.handlebars
+++ b/vis/templates/list/list_explorer.handlebars
@@ -20,14 +20,14 @@
                 {{#if dropdown}}
                 <div class="dropdown">
                     <button class="btn btn-primary dropdown-toggle" id="sort" type="button" data-toggle="dropdown">
-                        sort by:
+                        {{sort_by_label}}
                         <span id="curr-sort-type"></span>
                         <span class="caret"></span>
                     </button>
                     <ul id="sort-menu-entries" class="dropdown-menu" role="menu" aria-labelledby="sort-menu">
                     </ul>
                     {{else}}
-                    <span id="sortby">sort by:</span>
+                    <span id="sortby">{{sort_by_label}}</span>
                     <div id="sort-buttons" class="btn-group btn-group-sm pull-right" data-toggle="buttons" role="group"></div>
                     {{/if}}
                 </div>

--- a/vis/templates/list/list_explorer.handlebars
+++ b/vis/templates/list/list_explorer.handlebars
@@ -24,7 +24,7 @@
                         <span id="curr-sort-type"></span>
                         <span class="caret"></span>
                     </button>
-                    <ul id="sort-menu-entries" class="dropdown-menu" role="menu" aria-labelledby="sort-menu">
+                    <ul id="sort-menu-entries" class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="sort-menu">
                     </ul>
                     {{else}}
                     <span id="sortby">{{sort_by_label}}</span>

--- a/vis/templates/list/sort_dropdown_entry.handlebars
+++ b/vis/templates/list/sort_dropdown_entry.handlebars
@@ -1,3 +1,3 @@
 <li role="presentation">
-    <a role="menuitem" tabindex="-1">{{sort_by_string}} <b>{{sorter_label}}</b></a>
+    <a role="menuitem" tabindex="-1"><i class="sort_radio fa fa-circle-o"></i> {{sort_by_string}} <b>{{sorter_label}}</b></a>
 </li>

--- a/vis/templates/list/sort_dropdown_entry.handlebars
+++ b/vis/templates/list/sort_dropdown_entry.handlebars
@@ -1,0 +1,3 @@
+<li role="presentation">
+    <a role="menuitem" tabindex="-1">{{sort_by_string}} <b>{{sorter_label}}</b></a>
+</li>

--- a/vis/templates/misc/scale_toolbar.handlebars
+++ b/vis/templates/misc/scale_toolbar.handlebars
@@ -1,9 +1,12 @@
-    <div class="scale-toolbar btn-group dropup">
-        <div class="dropdown">
+<div class="scale-toolbar btn-group dropup">
+    <div class="dropdown">
         <button class="btn btn-primary dropdown-toggle" id="scale-menu" type="button" data-toggle="dropdown">
-            Scale map by: <span id="curr-scale-type"></span> <span class="caret"></span>
+            {{scale_by_label}}
+            <span id="curr-scale-type"></span>
+            <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" role="menu" aria-labelledby="scale-menu">
         </ul>
         <span id="curr-scale-explaination"></span>
     </div>
+</div>


### PR DESCRIPTION
Add new config variable 'sort_menu_dropdown' with default of false
set to true in openaire config.

Add conditional section to list_explorer.handlebars. If
sort_menu_dropdown is true show bootstrap dropdown in place
of radio buttons.

in list .js rename addSortOption to addSortOptionButton for existing
functionality. Introduce new addSortOptionDropdownEntry.

Add "citations" as a sort type for viper and localisation too.

Small refactoring of template + localisation to aid clarity.