### PR TITLE
Refactoring of Filtering, Implement Filter dropdown and header item count

### DIFF
--- a/examples/viper/data-config_openaire.js
+++ b/examples/viper/data-config_openaire.js
@@ -15,6 +15,7 @@ var data_config = {
     show_dropdown: false,
     preview_type: "pdf",
     sort_options: ["title", "authors", "year"],
+    filter_menu_dropdown: true,
     is_force_areas: true,
     language: "eng_openaire",
     area_force_alpha: 0.015,

--- a/vis/js/default-config.js
+++ b/vis/js/default-config.js
@@ -75,8 +75,11 @@ var config = {
     create_title_from_context: false,
 
     sort_options: ["readers", "title", "authors", "year"],
+    filter_options: ["all", "open_access", "publication", "dataset"],
 
     content_based: false,
+
+    filter_menu_dropdown: false,
 
     // transition
     transition_duration: 750,
@@ -265,6 +268,11 @@ var config = {
             viper_edit_button_text: 'continue to openaire',
             viper_embed_button_text: 'Copy',
             viper_embed_title: 'embed map',
+            filter_by_label: 'show: ',
+            all: "any",
+            open_access: "Open Access",
+            publication: "papers",
+            dataset: "datasets",
         }
     },
 

--- a/vis/js/default-config.js
+++ b/vis/js/default-config.js
@@ -273,6 +273,7 @@ var config = {
             open_access: "Open Access",
             publication: "papers",
             dataset: "datasets",
+            items: "items",
         }
     },
 

--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -140,6 +140,7 @@ list.drawList = function() {
 
     // Add filter options
     if(config.filter_menu_dropdown) {
+        $('#curr-filter-type').text(config.localization[config.language]['all'])
         for (var i = 0; i < config.filter_options.length; i++) {
             self.addFilterOptionDropdownEntry(config.filter_options[i])
         }

--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -547,11 +547,11 @@ list.filterList = function(search_words, filter_param) {
     mediator.publish("record_action", "none", "filter", config.user_id, "filter_list", null, "search_words=" + search_words + "filter_param="+filter_param);
 
     // Now actually do the filtering (i.e. remove some object from list and map)
-    this.hideEntriesByWord(all_list_items, search_words);
-    this.hideEntriesByWord(all_map_items, search_words);
+    this.hideEntriesByWord(selected_list_items, search_words);
+    this.hideEntriesByWord(normally_visible_map_items, search_words);
 
-    this.hideEntriesByParam(all_list_items, filter_param);
-    this.hideEntriesByParam(all_map_items, filter_param);
+    this.hideEntriesByParam(selected_list_items, filter_param);
+    this.hideEntriesByParam(normally_visible_map_items, filter_param);
 };
 
 // Returns true if document has parameter or if no parameter is passed

--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -545,15 +545,15 @@ list.findEntriesWithParam = function (param, d) {
     
 }
 
+// These functions only hide items. They shouldn't unhide them.
 list.hideEntriesByParam = function (object, param) {
     var self = this
     object.filter(function (d) {
         if (!self.findEntriesWithParam(param, d)) {
             d.filtered_out = true
-        } else {
-            d.filtered_out = false
+            return true
         }
-        return d.filtered_out
+        return false
     })
     .style("display", "none")
 }
@@ -579,8 +579,11 @@ list.hideEntriesByWord = function(object, search_words) {
                 );
                 i++;
             }
-            d.filtered_out = word_found ? false : true;
-            return d.filtered_out;
+            if (word_found === false) {
+                d.filtered_out = true
+                return true
+            }
+            return false
         })
         .style("display", "none");
 };

--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -539,7 +539,7 @@ list.filterList = function(search_words, filter_param) {
     normally_visible_map_items.style("display", "inline");
 
     //set everything that should be visible to unfiltered
-    selected_list_items.each(function (d) {
+    all_list_items.each(function (d) {
         d.filtered_out = false
     })
 
@@ -547,11 +547,11 @@ list.filterList = function(search_words, filter_param) {
     mediator.publish("record_action", "none", "filter", config.user_id, "filter_list", null, "search_words=" + search_words + "filter_param="+filter_param);
 
     // Now actually do the filtering (i.e. remove some object from list and map)
-    this.hideEntriesByWord(selected_list_items, search_words);
-    this.hideEntriesByWord(normally_visible_map_items, search_words);
+    this.hideEntriesByWord(all_list_items, search_words);
+    this.hideEntriesByWord(all_map_items, search_words);
 
-    this.hideEntriesByParam(selected_list_items, filter_param);
-    this.hideEntriesByParam(normally_visible_map_items, filter_param);
+    this.hideEntriesByParam(all_list_items, filter_param);
+    this.hideEntriesByParam(all_map_items, filter_param);
 };
 
 // Returns true if document has parameter or if no parameter is passed

--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -19,6 +19,7 @@ import {
 const listTemplate = require('templates/list/list_explorer.handlebars');
 const selectButtonTemplate = require('templates/list/select_button.handlebars');
 const listEntryTemplate = require("templates/list/list_entry.handlebars");
+const filterDropdownEntryTemplate = require("templates/list/filter_dropdown_entry.handlebars");
 
 export const list = StateMachine.create({
 
@@ -52,7 +53,7 @@ export const list = StateMachine.create({
             this.populateList();
             this.initListMouseListeners();
             sortBy(config.sort_options[0]);
-            this.current_search_words = ''
+            this.current_search_words = []
             this.current_filter_param = ''
         },
 
@@ -85,9 +86,13 @@ export const list = StateMachine.create({
 });
 
 list.drawList = function() {
+    let self = this
+
     // Load list template
     let list_explorer = listTemplate({
-        show_list: config.localization[config.language].show_list
+        show_list: config.localization[config.language].show_list,
+        filter_dropdown: config.filter_menu_dropdown,
+        filter_by_label: config.localization[config.language].filter_by_label,
     });
     $("#list_explorer").append(list_explorer);
 
@@ -119,6 +124,13 @@ list.drawList = function() {
             first_element = false;
         } else {
             addSortOption(container, config.sort_options[i], false);
+        }
+    }
+
+    // Add filter options
+    if(config.filter_menu_dropdown) {
+        for (var i = 0; i < config.filter_options.length; i++) {
+            self.addFilterOptionDropdownEntry(config.filter_options[i])
         }
     }
 
@@ -182,6 +194,18 @@ let addSortOption = function(parent, sort_option, selected) {
             config.user_id, "listsort", null, "sort_option=" + sort_option);
     });
 };
+
+list.addFilterOptionDropdownEntry = function (filter_option) {
+    let entry = filterDropdownEntryTemplate({
+        filter_by_string: config.localization[config.language].filter_by_label,
+        filter_label: config.localization[config.language][filter_option]
+    })
+    var newEntry = $(entry).appendTo('#filter-menu-entries')
+    newEntry.on("click", () => {
+        this.filterList(undefined, filter_option)
+        $('#curr-filter-type').text(config.localization[config.language][filter_option])
+    })
+}
 
 list.initListMouseListeners = function() {
     $("#show_hide_button")

--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -591,9 +591,11 @@ list.createHighlights = function(search_words) {
     }
 
     clear_highlights();
-    search_words.forEach(function(str) {
-        highlight(str);
-    });
+    if( !(search_words === "") ) {
+        search_words.forEach(function(str) {
+            highlight(str);
+        });
+    }
 };
 
 // called quite often

--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -510,27 +510,16 @@ list.filterList = function(search_words, filter_param) {
         selected_list_items = normally_visible_list_items;
     }
 
-    //If the search box is empty make every thing 'selected' in the list
-    // or normally visible in the map visible
-    // TODO: this causes a bug if the search box begins with a space
-    // no filtering is then done.
-    if (search_words[0].length === 0) {
-        // Why is block used here? everything is inline before and when any filtering is done
-        selected_list_items.style("display", "block");
-        normally_visible_map_items.style("display", "block");
-
-        mediator.current_bubble.data.forEach(function(d) {
-            d.filtered_out = false;
-        });
-
-        return;
-    }
-
     //Even if the search box isn't empty make everything visible
     selected_list_items.style("display", "inline");
     normally_visible_map_items.style("display", "inline");
 
-    // Record that we've done some filtering
+    //set everything that should be visible to unfiltered
+    selected_list_items.each(function (d) {
+        d.filtered_out = false
+    })
+
+    // Record that we're about to do some filtering
     mediator.publish("record_action", "none", "filter", config.user_id, "filter_list", null, "search_words=" + search_words + "filter_param="+filter_param);
 
     // Now actually do the filtering (i.e. remove some object from list and map)

--- a/vis/js/mediator.js
+++ b/vis/js/mediator.js
@@ -374,6 +374,7 @@ MyMediator.prototype = {
                 mediator.manager.call('list', 'updateByFiltered', []);
             }
         }
+        mediator.manager.call('list', 'filterList')
     },
     bubble_zoomout: function() {
         mediator.manager.call('list', 'reset', []);
@@ -383,6 +384,7 @@ MyMediator.prototype = {
         $("#map-rect").removeClass("zoomed_in").addClass('zoomed_out');
         $("#region.unframed").removeClass("zoomed_in");
         $(".paper_holder").removeClass("zoomed_in");
+        mediator.manager.call('list', 'filterList')
     },
 
     currentbubble_click: function(d) {

--- a/vis/js/mediator.js
+++ b/vis/js/mediator.js
@@ -374,7 +374,6 @@ MyMediator.prototype = {
                 mediator.manager.call('list', 'updateByFiltered', []);
             }
         }
-        mediator.manager.call('list', 'filterList')
     },
     bubble_zoomout: function() {
         mediator.manager.call('list', 'reset', []);
@@ -384,7 +383,6 @@ MyMediator.prototype = {
         $("#map-rect").removeClass("zoomed_in").addClass('zoomed_out');
         $("#region.unframed").removeClass("zoomed_in");
         $(".paper_holder").removeClass("zoomed_in");
-        mediator.manager.call('list', 'filterList')
     },
 
     currentbubble_click: function(d) {

--- a/vis/stylesheets/modules/list/_header.scss
+++ b/vis/stylesheets/modules/list/_header.scss
@@ -17,6 +17,11 @@
     padding-right: 22px;
 }
 
+#filter_parameter_container {
+    float: right;
+    display: block;
+}
+
 #sort_container {
     float: right;
     display: none;

--- a/vis/templates/list/filter_dropdown_entry.handlebars
+++ b/vis/templates/list/filter_dropdown_entry.handlebars
@@ -1,0 +1,3 @@
+<li role="presentation">
+    <a role="menuitem" tabindex="-1">{{filter_by_string}} <b>{{filter_label}}</b></a>
+</li>

--- a/vis/templates/list/list_explorer.handlebars
+++ b/vis/templates/list/list_explorer.handlebars
@@ -3,7 +3,7 @@
         <div id="show_hide_button" class="row">
             <div class="col-xs-2" >▼</div>
             <div class="col-xs-8" id="show_hide_button_label">
-                <span id="show_hide_label">{{ show_list }}</span>
+                <span id="show_hide_label"></span>
             </div>
             <div class="col-xs-2 text-right">▼</div>
         </div>

--- a/vis/templates/list/list_explorer.handlebars
+++ b/vis/templates/list/list_explorer.handlebars
@@ -18,12 +18,21 @@
                     <span id="searchclear" class="glyphicon glyphicon-remove-circle"></span>
                 </div>
             </div>
-
             <div class="" id="sort_container">
 <span id="sortby">sort by:</span>
                 <div id="sort-buttons" class="btn-group btn-group-sm pull-right" data-toggle="buttons" role="group">
                 </div>
             </div>
+            {{#if filter_dropdown}}
+            <div class="" id="filter_parameter_container">
+                <button class="btn btn-primary dropdown-toggle" id="filter_params" type="button" data-toggle="dropdown">{{filter_by_label}}
+                    <span id="curr-filter-type"></span>
+                    <span class="caret"></span>
+                </button>
+                <ul id="filter-menu-entries" class="dropdown-menu" role="menu" aria-labelledby="sort-menu">
+                </ul>
+            </div>
+            {{/if}}
         </div>
     </div>
 <div class="col-xs-12" id="papers_list"></div>

--- a/vis/templates/list/show_hide_label.handlebars
+++ b/vis/templates/list/show_hide_label.handlebars
@@ -1,0 +1,1 @@
+<span>{{ show_or_hide_list }} <span id="list_item_banner">(<span id="list_item_count">{{item_count}}</span> {{items}})</span></span>


### PR DESCRIPTION
Everything in #237 but also fix for the bug @pkraker found.

Also includes header item count. This is done by working through the list, filtering for those items that "should" be in the current view and then counting those that are not marked as filtered_out: true

The implementation is rather ugly because determining what "should" be in the current view is determined after the transition.

Since I was pushed for time and couldn't see a better way to figure out either what the transition was or when it would finish it simply has a "magic" number wait.

You can therefore mess with it by transitioning very quickly.

It would be nicest to have another field in the data for example, "is_visible" which we toggle as zooming in and out.