### PR TITLE
fix scale toolbar gap

### DIFF
--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -130,7 +130,7 @@ list.drawList = function() {
 
 list.fit_list_height = function() {
     var paper_list_avail_height = null;
-    const PAPER_LIST_CORRECTION = 10;
+    const PAPER_LIST_CORRECTION = -5;
     if (!config.render_bubbles) {
         var parent_height = getRealHeight($("#" + config.tag));
         var available_height = 0;


### PR DESCRIPTION
As you can see I just poked a single magic number.

Looks like it was originally introduced more than a year ago.

I imagine this is some function of the css and thus might need another poke after Maxi has done up the padding.