### PR TITLE
fix #261

### DIFF
--- a/server/services/updateViper.php
+++ b/server/services/updateViper.php
@@ -147,9 +147,10 @@ function runUpdate($acronymtitle, $params) {
   $decoded_params = decodeParams($params);
   $post_params = $decoded_params[0];
   $param_types = $decoded_params[1];
+  $params_for_id = array("project_id", "funder");
   $result = search("openaire", $acronymtitle,
                                      $params, $param_types,
-                                     ";", null, false, false);
+                                     ";", null, false, false, $params_for_id);
   echo $result;
 }
 


### PR DESCRIPTION
* the subset of params (project_id and funder) which is utilized in searchOpenAIRE is now used as `params_for_id` in the update component as well
* this should solve the issue that maps created under new IDs are not being updated