### PR TITLE
critical preprocessing bugfix

### DIFF
--- a/server/preprocessing/other-scripts/preprocess.R
+++ b/server/preprocessing/other-scripts/preprocess.R
@@ -99,7 +99,7 @@ replace_keywords_if_empty <- function(metadata, stops) {
 }
 
 get_OHE_feature <-function(metadata, feature_name) {
-  ohe_encoder <- onehot(metadata[feature_name], stringsAsFactors = TRUE)
+  ohe_encoder <- onehot(metadata[feature_name], stringsAsFactors = TRUE, max_levels = 100)
   ohe_feat <- data.frame(predict(ohe_encoder, metadata[feature_name]))
   rownames(ohe_feat) <- metadata$id
   return(ohe_feat)


### PR DESCRIPTION
When too many languages are detected previously, the encoder breaks due to a too low threshold.