### PR TITLE
Logging fixes

### DIFF
--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -36,7 +36,7 @@ blog <- getLogger('api.base')
 get_papers <- function(query, params, limit=100,
                        fields="title,id,counter_total_month,abstract,journal,publication_date,author,subject,article_type") {
 
-  blog$info(paste("Search: ", query, sep=""))
+  blog$info(paste("Search:", query))
   start.time <- Sys.time()
 
   exact_query = "";

--- a/server/preprocessing/other-scripts/pubmed.R
+++ b/server/preprocessing/other-scripts/pubmed.R
@@ -39,7 +39,7 @@ plog <- getLogger('api.pubmed')
 
 
 get_papers <- function(query, params = NULL, limit = 100) {
-  plog$info(query)
+  plog$info(paste("Search:", query))
   start.time <- Sys.time()
 
   fields <- c('.//ArticleTitle', './/MedlineCitation/PMID', './/Title', './/Abstract')
@@ -60,7 +60,7 @@ get_papers <- function(query, params = NULL, limit = 100) {
   #HOTFIX - article_types cause a 414 with PubMed
   #query <- paste0(query, article_types_string, exclude_articles_with_abstract)
   query <- paste0(query, exclude_articles_with_abstract)
-  plog$info(query)
+  plog$info(paste("Query:", query))
   x <- rentrez::entrez_search(db = "pubmed", term = query, retmax = limit,
                               mindate = from, maxdate = to, sort=sortby, use_history=TRUE)
   res <- rentrez::entrez_fetch(db = "pubmed", web_history = x$web_history, retmax = limit, rettype = "xml")

--- a/server/preprocessing/other-scripts/test/base-snapshot-ger.R
+++ b/server/preprocessing/other-scripts/test/base-snapshot-ger.R
@@ -47,7 +47,7 @@ output_json = vis_layout(input_data$text, input_data$metadata,
                          add_stop_words=ADDITIONAL_STOP_WORDS,
                          testing=TRUE, list_size=100)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 output <- data.frame(fromJSON(output_json))

--- a/server/preprocessing/other-scripts/test/base-snapshot-ger.R
+++ b/server/preprocessing/other-scripts/test/base-snapshot-ger.R
@@ -23,6 +23,8 @@ if (DEBUG==TRUE){
   setup_logging('INFO')
 }
 
+tslog <- getLogger('ts')
+
 source("../vis_layout.R")
 source('../base.R')
 
@@ -38,11 +40,15 @@ input_data = fromJSON("snapshots/snapshot_base_input-ger.json")
 #time.taken <- end.time - start.time
 #time.taken
 
+tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata,
                          max_clusters=MAX_CLUSTERS,
                          lang = LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS,
                          testing=TRUE, list_size=100)
+}, error=function(err){
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+})
 
 output <- data.frame(fromJSON(output_json))
 expected <- fromJSON("snapshots/snapshot_base_expected-ger.json")

--- a/server/preprocessing/other-scripts/test/base-snapshot-ger.R
+++ b/server/preprocessing/other-scripts/test/base-snapshot-ger.R
@@ -47,7 +47,7 @@ output_json = vis_layout(input_data$text, input_data$metadata,
                          add_stop_words=ADDITIONAL_STOP_WORDS,
                          testing=TRUE, list_size=100)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
+tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 output <- data.frame(fromJSON(output_json))

--- a/server/preprocessing/other-scripts/test/base-snapshot.R
+++ b/server/preprocessing/other-scripts/test/base-snapshot.R
@@ -45,7 +45,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
+tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 output <- data.frame(fromJSON(output_json))

--- a/server/preprocessing/other-scripts/test/base-snapshot.R
+++ b/server/preprocessing/other-scripts/test/base-snapshot.R
@@ -45,7 +45,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 output <- data.frame(fromJSON(output_json))

--- a/server/preprocessing/other-scripts/test/base-snapshot.R
+++ b/server/preprocessing/other-scripts/test/base-snapshot.R
@@ -23,6 +23,8 @@ if (DEBUG==TRUE){
   setup_logging('INFO')
 }
 
+tslog <- getLogger('ts')
+
 source("../vis_layout.R")
 source('../base.R')
 
@@ -38,9 +40,13 @@ input_data = fromJSON("snapshots/snapshot_base_input.json")
 #time.taken <- end.time - start.time
 #time.taken
 
+tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS,
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
+}, error=function(err){
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+})
 
 output <- data.frame(fromJSON(output_json))
 expected <- fromJSON("snapshots/snapshot_base_expected.json")

--- a/server/preprocessing/other-scripts/test/base-test-ger.R
+++ b/server/preprocessing/other-scripts/test/base-test-ger.R
@@ -42,7 +42,7 @@ if(!is.null(params_file)) {
 tryCatch({
   input_data = get_papers(query, params, limit=120)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 
 #end.time <- Sys.time()
@@ -55,7 +55,7 @@ output_json = vis_layout(input_data$text, input_data$metadata,
                          add_stop_words = ADDITIONAL_STOP_WORDS,
                          testing=TRUE, list_size=100)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/base-test-ger.R
+++ b/server/preprocessing/other-scripts/test/base-test-ger.R
@@ -21,6 +21,8 @@ if (DEBUG==TRUE){
   setup_logging('INFO')
 }
 
+tslog <- getLogger('ts')
+
 source("../vis_layout.R")
 source('../base.R')
 
@@ -37,16 +39,23 @@ if(!is.null(params_file)) {
 
 
 
-input_data = get_papers(query, params, limit=120)
+tryCatch({
+  input_data = get_papers(query, params, limit=120)
+}, error=function(err){
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+})
 
 #end.time <- Sys.time()
 #time.taken <- end.time - start.time
 #time.taken
-
+tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata,
                          max_clusters = MAX_CLUSTERS,
                          lang = LANGUAGE,
                          add_stop_words = ADDITIONAL_STOP_WORDS,
                          testing=TRUE, list_size=100)
+}, error=function(err){
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+})
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/base-test-ger.R
+++ b/server/preprocessing/other-scripts/test/base-test-ger.R
@@ -42,7 +42,7 @@ if(!is.null(params_file)) {
 tryCatch({
   input_data = get_papers(query, params, limit=120)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 
 #end.time <- Sys.time()
@@ -55,7 +55,7 @@ output_json = vis_layout(input_data$text, input_data$metadata,
                          add_stop_words = ADDITIONAL_STOP_WORDS,
                          testing=TRUE, list_size=100)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
+tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -39,7 +39,7 @@ if(!is.null(params_file)) {
 tryCatch({
   input_data = get_papers(query, params, limit=120)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 
 #end.time <- Sys.time()
@@ -50,7 +50,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
+tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -7,7 +7,7 @@ options(warn=1)
 wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
 setwd(wd) #Don't forget to set your working directory
 
-query <- "editorial" #args[2]
+query <- "edelstahl 1.4303" #args[2]
 service <- "base"
 params <- NULL
 params_file <- "params_base.json"
@@ -39,7 +39,7 @@ if(!is.null(params_file)) {
 tryCatch({
   input_data = get_papers(query, params, limit=120)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 
 #end.time <- Sys.time()
@@ -50,7 +50,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -21,6 +21,8 @@ if (DEBUG==TRUE){
   setup_logging('INFO')
 }
 
+tslog <- getLogger('ts')
+
 source("../vis_layout.R")
 source('../base.R')
 
@@ -34,14 +36,21 @@ if(!is.null(params_file)) {
 
 #start.time <- Sys.time()
 
-input_data = get_papers(query, params, limit=120)
+tryCatch({
+  input_data = get_papers(query, params, limit=120)
+}, error=function(err){
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+})
 
 #end.time <- Sys.time()
 #time.taken <- end.time - start.time
 #time.taken
-
+tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS,
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
+}, error=function(err){
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+})
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/create_snapshots.R
+++ b/server/preprocessing/other-scripts/test/create_snapshots.R
@@ -25,6 +25,8 @@ if (DEBUG==TRUE){
   setup_logging('INFO')
 }
 
+tslog <- getLogger('ts')
+
 source("../vis_layout.R")
 source('../base.R')
 
@@ -39,15 +41,22 @@ if(!is.null(params_file)) {
 
 #start.time <- Sys.time()
 
-input_data = get_papers(query, params, limit=120)
+tryCatch({
+  input_data = get_papers(query, params, limit=120)
+}, error=function(err){
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+})
 write_json(input_data, "snapshots/snapshot_base_input.json")
 #end.time <- Sys.time()
 #time.taken <- end.time - start.time
 #time.taken
-
+tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS,
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
+}, error=function(err){
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+})
 
 write_json(data.frame(fromJSON(output_json)), "snapshots/snapshot_base_expected.json")
 
@@ -92,13 +101,21 @@ if(!is.null(params_file)) {
 
 #start.time <- Sys.time()
 
-input_data = get_papers(query, params)
+tryCatch({
+  input_data = get_papers(query, params)
+}, error=function(err){
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+})
 write_json(input_data, "snapshots/snapshot_pubmed_input.json")
 #end.time <- Sys.time()
 #time.taken <- end.time - start.time
 #time.taken
-
+tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS,
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
+}, error=function(err){
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+})
+
 write_json(data.frame(fromJSON(output_json)), "snapshots/snapshot_pubmed_expected.json")

--- a/server/preprocessing/other-scripts/test/create_snapshots.R
+++ b/server/preprocessing/other-scripts/test/create_snapshots.R
@@ -44,7 +44,7 @@ if(!is.null(params_file)) {
 tryCatch({
   input_data = get_papers(query, params, limit=120)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 write_json(input_data, "snapshots/snapshot_base_input.json")
 #end.time <- Sys.time()
@@ -55,7 +55,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err)))
 })
 
 write_json(data.frame(fromJSON(output_json)), "snapshots/snapshot_base_expected.json")
@@ -104,7 +104,7 @@ if(!is.null(params_file)) {
 tryCatch({
   input_data = get_papers(query, params)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 write_json(input_data, "snapshots/snapshot_pubmed_input.json")
 #end.time <- Sys.time()
@@ -115,7 +115,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 write_json(data.frame(fromJSON(output_json)), "snapshots/snapshot_pubmed_expected.json")

--- a/server/preprocessing/other-scripts/test/create_snapshots.R
+++ b/server/preprocessing/other-scripts/test/create_snapshots.R
@@ -44,7 +44,7 @@ if(!is.null(params_file)) {
 tryCatch({
   input_data = get_papers(query, params, limit=120)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 write_json(input_data, "snapshots/snapshot_base_input.json")
 #end.time <- Sys.time()
@@ -55,7 +55,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err)))
+tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err)))
 })
 
 write_json(data.frame(fromJSON(output_json)), "snapshots/snapshot_base_expected.json")
@@ -104,7 +104,7 @@ if(!is.null(params_file)) {
 tryCatch({
   input_data = get_papers(query, params)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 write_json(input_data, "snapshots/snapshot_pubmed_input.json")
 #end.time <- Sys.time()
@@ -115,7 +115,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
+tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 write_json(data.frame(fromJSON(output_json)), "snapshots/snapshot_pubmed_expected.json")

--- a/server/preprocessing/other-scripts/test/pubmed-snapshot.R
+++ b/server/preprocessing/other-scripts/test/pubmed-snapshot.R
@@ -22,6 +22,8 @@ if (DEBUG==TRUE){
   setup_logging('INFO')
 }
 
+tslog <- getLogger('ts')
+
 source("../vis_layout.R")
 source('../pubmed.R')
 
@@ -37,10 +39,13 @@ input_data = fromJSON("snapshots/snapshot_pubmed_input.json")
 #end.time <- Sys.time()
 #time.taken <- end.time - start.time
 #time.taken
-
+tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS,
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
+}, error=function(err){
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+})
 
 output <- data.frame(fromJSON(output_json))
 expected <- fromJSON("snapshots/snapshot_pubmed_expected.json")

--- a/server/preprocessing/other-scripts/test/pubmed-snapshot.R
+++ b/server/preprocessing/other-scripts/test/pubmed-snapshot.R
@@ -44,7 +44,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
+tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 output <- data.frame(fromJSON(output_json))

--- a/server/preprocessing/other-scripts/test/pubmed-snapshot.R
+++ b/server/preprocessing/other-scripts/test/pubmed-snapshot.R
@@ -44,7 +44,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 output <- data.frame(fromJSON(output_json))

--- a/server/preprocessing/other-scripts/test/pubmed-test.R
+++ b/server/preprocessing/other-scripts/test/pubmed-test.R
@@ -40,7 +40,7 @@ if(!is.null(params_file)) {
 tryCatch({
   input_data = get_papers(query, params)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 
 #end.time <- Sys.time()
@@ -51,7 +51,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/pubmed-test.R
+++ b/server/preprocessing/other-scripts/test/pubmed-test.R
@@ -22,6 +22,8 @@ if (DEBUG==TRUE){
   setup_logging('INFO')
 }
 
+tslog <- getLogger('ts')
+
 source("../vis_layout.R")
 source('../pubmed.R')
 
@@ -35,14 +37,21 @@ if(!is.null(params_file)) {
 
 #start.time <- Sys.time()
 
-input_data = get_papers(query, params)
+tryCatch({
+  input_data = get_papers(query, params)
+}, error=function(err){
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+})
 
 #end.time <- Sys.time()
 #time.taken <- end.time - start.time
 #time.taken
-
+tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS,
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
+}, error=function(err){
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+})
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/pubmed-test.R
+++ b/server/preprocessing/other-scripts/test/pubmed-test.R
@@ -40,7 +40,7 @@ if(!is.null(params_file)) {
 tryCatch({
   input_data = get_papers(query, params)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 
 #end.time <- Sys.time()
@@ -51,7 +51,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
+tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/test-openaire.R
+++ b/server/preprocessing/other-scripts/test/test-openaire.R
@@ -23,6 +23,8 @@ if (DEBUG==TRUE){
   setup_logging('INFO')
 }
 
+tslog <- getLogger('ts')
+
 source("../vis_layout.R")
 source('../openaire.R')
 source('../altmetrics.R')
@@ -36,11 +38,19 @@ if(!is.null(params_file)) {
 }
 
 
-input_data = get_papers(query, params)
+tryCatch({
+  input_data = get_papers(query, params)
+}, error=function(err){
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+})
 
+tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS,
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=-1)
+}, error=function(err){
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+})
 
 if (service=='openaire'){
   output_json_with_metrics = enrich_output_json(output_json)

--- a/server/preprocessing/other-scripts/test/test-openaire.R
+++ b/server/preprocessing/other-scripts/test/test-openaire.R
@@ -41,7 +41,7 @@ if(!is.null(params_file)) {
 tryCatch({
   input_data = get_papers(query, params)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 
 tryCatch({
@@ -49,7 +49,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=-1)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
+tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 if (service=='openaire'){

--- a/server/preprocessing/other-scripts/test/test-openaire.R
+++ b/server/preprocessing/other-scripts/test/test-openaire.R
@@ -41,7 +41,7 @@ if(!is.null(params_file)) {
 tryCatch({
   input_data = get_papers(query, params)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 
 tryCatch({
@@ -49,7 +49,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=-1)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 if (service=='openaire'){

--- a/server/preprocessing/other-scripts/text_similarity.R
+++ b/server/preprocessing/other-scripts/text_similarity.R
@@ -80,7 +80,7 @@ print(params)
 tryCatch({
   input_data = get_papers(query, params, limit=limit)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", query, params, err)))
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
 })
 
 

--- a/server/preprocessing/other-scripts/text_similarity.R
+++ b/server/preprocessing/other-scripts/text_similarity.R
@@ -80,7 +80,7 @@ print(params)
 tryCatch({
   input_data = get_papers(query, params, limit=limit)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 
 
@@ -90,7 +90,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          taxonomy_separator=taxonomy_separator, list_size = list_size)
 }, error=function(err){
- tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
+ tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 if (service=='openaire'){

--- a/server/preprocessing/other-scripts/text_similarity.R
+++ b/server/preprocessing/other-scripts/text_similarity.R
@@ -80,7 +80,7 @@ print(params)
 tryCatch({
   input_data = get_papers(query, params, limit=limit)
 }, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, params, err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Query failed:", service, query, paste(params, collapse=" "), err, sep="||")))
 })
 
 
@@ -90,7 +90,7 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE,
                          taxonomy_separator=taxonomy_separator, list_size = list_size)
 }, error=function(err){
- tslog$error(gsub("\n", " ", paste("Processing failed:", query, params, err)))
+ tslog$error(gsub("\n", " ", paste("Processing failed:", query, paste(params, collapse=" "), err, sep="||")))
 })
 
 if (service=='openaire'){


### PR DESCRIPTION
This PR fixes two aspects in our logging system:
* The tests now more closely mirror the logging output in production: The get_papers method and the vis_layout method have been wrapped by error loggers
* The logging output for get_papers and vis_layout has been fixed, previously it was
```
2018-09-21 09:37:13 ERROR:ts:Query failed: "informal learning"+""cognitive load"+"augmented reality" 1665-01-01 Error in matrix(nrow = length(res$dcdocid)): data is too long
 2018-09-21 09:37:13 ERROR:ts:Query failed: "informal learning"+""cognitive load"+"augmented reality" 2018-09-21 Error in matrix(nrow = length(res$dcdocid)): data is too long
 2018-09-21 09:37:13 ERROR:ts:Query failed: "informal learning"+""cognitive load"+"augmented reality" 121 Error in matrix(nrow = length(res$dcdocid)): data is too long
 2018-09-21 09:37:13 ERROR:ts:Query failed: "informal learning"+""cognitive load"+"augmented reality" most-relevant Error in matrix(nrow = length(res$dcdocid)): data is too long
```
due to the param list not being collapsed. This lead to an overcounting of errors. Now the message is correctly composed and can also more easily be parsed:
```
2018-09-21 09:37:13 ERROR:ts:Query failed ||"informal learning"+""cognitive load"+"augmented reality" ||1665-01-01 2018-09-21 121 most-relevant||Error in matrix(nrow = length(res$dcdocid)): data is too long
```