### PR TITLE
fixed #291

### DIFF
--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -28,6 +28,10 @@ vis_layout <- function(text, metadata,
                        testing=FALSE, taxonomy_separator=NULL, list_size=-1) {
   TESTING <<- testing # makes testing param a global variable
   start.time <- Sys.time()
+  
+  if(!exists('input_data')){
+    stop("No input data found.")
+  }
 
   tryCatch({
    if(!isTRUE(testing)) {


### PR DESCRIPTION
Now leaves vis_layout early if no input_data exists, returns an error to text_similarity.