### PR TITLE
fixed #292

### DIFF
--- a/server/preprocessing/other-scripts/cluster.R
+++ b/server/preprocessing/other-scripts/cluster.R
@@ -9,6 +9,9 @@ get_cut_off <- function(css_cluster, attempt=1){
 }
 
 create_clusters <- function(distance_matrix, max_clusters=-1, method="ward.D") {
+  if(nrow(distance_matrix) <= 2){
+    stop("Not enough papers for clustering, N <= 2.")
+  }
   # Perform clustering, use elbow to determine a good number of clusters
   css_cluster <- css.hclust(distance_matrix, hclust.FUN.MoreArgs=list(method="ward.D"))
   num_clusters <- NA

--- a/server/preprocessing/other-scripts/cluster.R
+++ b/server/preprocessing/other-scripts/cluster.R
@@ -9,8 +9,8 @@ get_cut_off <- function(css_cluster, attempt=1){
 }
 
 create_clusters <- function(distance_matrix, max_clusters=-1, method="ward.D") {
-  if(nrow(distance_matrix) <= 2){
-    stop("Not enough papers for clustering, N <= 2.")
+  if(nrow(distance_matrix) < 2){
+    stop("Not enough papers for clustering, N < 2.")
   }
   # Perform clustering, use elbow to determine a good number of clusters
   css_cluster <- css.hclust(distance_matrix, hclust.FUN.MoreArgs=list(method="ward.D"))


### PR DESCRIPTION
In the rare cases when only 1 paper is returned, clustering fails. This is now handled explicitly and an error returned to text_similarity.
Please merge after #295 and #296 , as this error handling will only become apparent when the previous ones are handled correctly.