### PR TITLE
fixed 293

### DIFF
--- a/server/preprocessing/other-scripts/cluster.R
+++ b/server/preprocessing/other-scripts/cluster.R
@@ -87,10 +87,16 @@ get_ndms <- function(distance_matrix, mindim=2, maxdim=2, maxit=500) {
   # Perform non-metric multidimensional scaling
   # nm <- par.nmds(distance_matrix, mindim=mindim, maxdim=maxdim, maxit=maxit)
   # nm.nmin = nmds.min(nm)
-  ord <- metaMDS(distance_matrix, k = 2, parallel = 3)
-  points <- ord$points
+  print(nrow(distance_matrix))
+  print(distance_matrix)
+  if (nrow(distance_matrix) <= 2){
+    points <- cbind(runif(nrow(distance_matrix), min=-1), runif(nrow(distance_matrix)), min=-1)
+  } else {
+    ord <- metaMDS(distance_matrix, k = 2, parallel = 3)
+    points <- ord$points
+    vclog$info(paste("NMDS-Stress:", min(ord$stress), sep=" "))
+  }
 
-  vclog$info(paste("NMDS-Stress:", min(ord$stress), sep=" "))
   # vclog$info(paste("NMDS-R2:", min(nm$r2), sep=" "))
 
   # NEEDS FIX

--- a/server/preprocessing/other-scripts/cluster.R
+++ b/server/preprocessing/other-scripts/cluster.R
@@ -87,10 +87,15 @@ get_ndms <- function(distance_matrix, mindim=2, maxdim=2, maxit=500) {
   # Perform non-metric multidimensional scaling
   # nm <- par.nmds(distance_matrix, mindim=mindim, maxdim=maxdim, maxit=maxit)
   # nm.nmin = nmds.min(nm)
-  print(nrow(distance_matrix))
-  print(distance_matrix)
   if (nrow(distance_matrix) <= 2){
-    points <- cbind(runif(nrow(distance_matrix), min=-1), runif(nrow(distance_matrix)), min=-1)
+    points <- tryCatch({
+      ord <- metaMDS(distance_matrix, k = 2, parallel = 3)
+      points <- ord$points
+    }, error=function(err){
+      points <- rbind(runif(nrow(distance_matrix), min=-1, max=0),
+                      runif(nrow(distance_matrix), min=0, max=1))
+      return(points)
+    })
   } else {
     ord <- metaMDS(distance_matrix, k = 2, parallel = 3)
     points <- ord$points


### PR DESCRIPTION
In the rare cases when only one or two papers are present, the NMDS ordination fails. This is now handled by catching this situation, and instead of getting a layout, random X-Y coordinates are assigned to the 1 or 2 papers between [-1, 1].