### PR TITLE
Base langsearch

### DIFF
--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -1,4 +1,4 @@
-'='library(rbace)
+library(rbace)
 
 # get_papers
 #
@@ -139,17 +139,6 @@ get_papers <- function(query, params, limit=100,
 
   return(ret_val)
 
-}
-
-get_lang <- function(lang_id) {
-  if (lang_id == 'all'){
-    LANGUAGE <- 'english'
-    } else if (lang_id %in% names(valid_langs)){
-      LANGUAGE <- unlist(unname(valid_langs[lang_id]))
-    } else {
-      LANGUAGE <- 'english'
-    }
-  return (list(lang_id = lang_id, name = LANGUAGE))
 }
 
 valid_langs <- list(

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -56,7 +56,7 @@ get_papers <- function(query, params, limit=100,
   document_types = paste("dctypenorm:", "(", paste(params$document_types, collapse=" OR "), ")", sep="")
   # language query field flag
   # CHANGE TO MORE LANGUAGES!!! look up dclang specifications
-  lang_id <- params$language_id
+  lang_id <- params$lang_id
   if (lang_id %in% names(valid_langs)) {
     lang_query <- paste0("dclang:", lang_id)
     } else {
@@ -78,7 +78,7 @@ get_papers <- function(query, params, limit=100,
     stop(paste("No results retrieved."))
   }
 
-  blog$info(paste("Query:", query, date_string, document_types, abstract_exists, sep=" "));
+  blog$info(paste("Query:", query, lang_query, date_string, document_types, abstract_exists, sep=" "));
 
   metadata = data.frame(matrix(nrow=length(res$dcdocid)))
 

--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -217,3 +217,8 @@ queries <- function(titles){
   }
   return (queries)
 }
+
+
+valid_langs <- list(
+    'eng'='english'
+)

--- a/server/preprocessing/other-scripts/pubmed.R
+++ b/server/preprocessing/other-scripts/pubmed.R
@@ -149,3 +149,8 @@ get_papers <- function(query, params = NULL, limit = 100) {
 }
 
 xtext <- function(x) xml2::xml_text(x)
+
+
+valid_langs <- list(
+    'eng'='english'
+)

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -28,18 +28,18 @@ source('../base.R')
 
 MAX_CLUSTERS = 15
 
-if ('language' %in% names(params)){
-    lang <- map_language(params$language_id)
-  } else {
-    lang <- 'all'
-  }
-
-LANGUAGE <- get_lang(lang)
-ADDITIONAL_STOP_WORDS = LANGUAGE$name
-
 if(!is.null(params_file)) {
   params <- fromJSON(params_file)
 }
+
+if ('lang_id' %in% names(params)){
+    lang_id <- params$lang_id
+  } else {
+    lang_id <- 'all'
+}
+
+LANGUAGE <- get_api_lang(lang_id, valid_langs)
+ADDITIONAL_STOP_WORDS = LANGUAGE$name
 
 #start.time <- Sys.time()
 

--- a/server/preprocessing/other-scripts/test/pubmed-test.R
+++ b/server/preprocessing/other-scripts/test/pubmed-test.R
@@ -5,7 +5,6 @@ library(rstudioapi)
 options(warn=1)
 
 wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
-
 setwd(wd) #Don't forget to set your working directory
 
 query <- "russian" #args[2]
@@ -28,12 +27,19 @@ source("../vis_layout.R")
 source('../pubmed.R')
 
 MAX_CLUSTERS = 15
-LANGUAGE = "english"
-ADDITIONAL_STOP_WORDS = "english"
 
 if(!is.null(params_file)) {
   params <- fromJSON(params_file)
 }
+
+if ('lang_id' %in% names(params)){
+    lang_id <- params$lang_id
+  } else {
+    lang_id <- 'all'
+}
+
+LANGUAGE <- get_api_lang(lang_id, valid_langs)
+ADDITIONAL_STOP_WORDS = LANGUAGE$name
 
 #start.time <- Sys.time()
 
@@ -48,7 +54,7 @@ tryCatch({
 #time.taken
 tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS,
-                         lang=LANGUAGE,
+                         lang=LANGUAGE$name,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
 }, error=function(err){
 tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))

--- a/server/preprocessing/other-scripts/test/test-openaire.R
+++ b/server/preprocessing/other-scripts/test/test-openaire.R
@@ -30,12 +30,19 @@ source('../openaire.R')
 source('../altmetrics.R')
 
 MAX_CLUSTERS = 15
-LANGUAGE = "english"
-ADDITIONAL_STOP_WORDS = "english"
 
 if(!is.null(params_file)) {
   params <- fromJSON(params_file)
 }
+
+if ('lang_id' %in% names(params)){
+    lang_id <- params$lang_id
+  } else {
+    lang_id <- 'all'
+}
+
+LANGUAGE <- get_api_lang(lang_id, valid_langs)
+ADDITIONAL_STOP_WORDS = LANGUAGE$name
 
 
 tryCatch({
@@ -46,7 +53,7 @@ tryCatch({
 
 tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS,
-                         lang=LANGUAGE,
+                         lang=LANGUAGE$name,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=-1)
 }, error=function(err){
 tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))

--- a/server/preprocessing/other-scripts/text_similarity.R
+++ b/server/preprocessing/other-scripts/text_similarity.R
@@ -65,16 +65,15 @@ if(!is.null(params_file) && !is.na(params_file)) {
   params <- NULL
 }
 
-if ('language' %in% names(params)){
-    LANGUAGE <- params$language
-    if (LANGUAGE == 'all'){
-      LANGUAGE <- 'english'
-    }
+if ('lang_id' %in% names(params)){
+    lang_id <- params$lang_id
   } else {
-    LANGUAGE <- 'english'
-  }
+    lang_id <- 'all'
+}
 
-ADDITIONAL_STOP_WORDS = LANGUAGE
+LANGUAGE <- get_api_lang(lang_id, valid_langs)
+ADDITIONAL_STOP_WORDS = LANGUAGE$name
+
 print("reading stuff")
 print(params)
 tryCatch({
@@ -87,7 +86,7 @@ tryCatch({
 print("got the input")
 tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS, add_stop_words=ADDITIONAL_STOP_WORDS,
-                         lang=LANGUAGE,
+                         lang=LANGUAGE$name,
                          taxonomy_separator=taxonomy_separator, list_size = list_size)
 }, error=function(err){
  tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -61,3 +61,15 @@ setup_logging <- function(loglevel) {
     addHandler(writeToFile, file=Sys.getenv("HEADSTART_LOGFILE"))
   }
 }
+
+
+get_api_lang <- function(lang_id, valid_langs) {
+  if (lang_id == 'all'){
+    LANGUAGE <- 'english'
+    } else if (lang_id %in% names(valid_langs)){
+      LANGUAGE <- unlist(unname(valid_langs[lang_id]))
+    } else {
+      LANGUAGE <- 'english'
+    }
+  return (list(lang_id = lang_id, name = LANGUAGE))
+}

--- a/server/services/searchBASE.php
+++ b/server/services/searchBASE.php
@@ -11,7 +11,7 @@ $dirty_query = library\CommUtils::getParameter($_POST, "q");
 
 $post_params = $_POST;
 
-$result = search("base", $dirty_query, $post_params, array("from", "to", "document_types", "sorting"), ";", null);
+$result = search("base", $dirty_query, $post_params, array("from", "to", "document_types", "sorting", "lang_id"), ";", null);
 
 echo $result
 


### PR DESCRIPTION
* Unified the lang-search APIs so that it works with and without language-parameters
* BASE now takes `lang_id` parameter; if not present, default behavior english is kept
* for other APIs default behavior english is kept