### PR TITLE
Fix labeling

### DIFF
--- a/examples/search_repos/search_options.js
+++ b/examples/search_repos/search_options.js
@@ -248,7 +248,59 @@ var options_base = {
                 , {id: "183", text: "Thesis: doctoral and postdoctoral", selected: false}
                 , {id: "182", text: "Thesis: master", selected: false}
                 , {id: "52", text: "Video/moving image", selected: false}
-            ]}
+            ]},
+        {id: "lang_id", multiple: false, name: "Language", type: "dropdown"
+            , fields: [
+                {id: "all", text: "All languages"}
+                , {id: "eng", text: "English"}
+                , {"id": "fre", "text": "French (français)"},
+                {"id": "spa", "text": "Spanish (español)"},
+                {"id": "ger", "text": "German (Deutsch)"},
+                {"id": "por", "text": "Portuguese (português)"},
+                {"id": "pol", "text": "Polish (Jezyk polski)"},
+                {"id": "jpn", "text": "Japanese (???)"},
+                {"id": "ita", "text": "Italian (italiano)"},
+                {"id": "chi", "text": "Chinese (??)"},
+                {"id": "rus", "text": "Russian (??????? ????)"},
+                {"id": "ind", "text": "Indonesian (bahasa Indonesia)"},
+                {"id": "ukr", "text": "Ukrainian (?????????? ????)"},
+                {"id": "gre", "text": "Modern Greek (??a ????????)"},
+                {"id": "cze", "text": "Czech (ceština)"},
+                {"id": "fin", "text": "Finnish (suomen kieli)"},
+                {"id": "swe", "text": "Swedish (svenska)"},
+                {"id": "hun", "text": "Hungarian (magyar nyelv)"},
+                {"id": "tur", "text": "Turkish (Türkçe)"},
+                {"id": "hrv", "text": "Croatian (hrvatski)"},
+                {"id": "geo", "text": "Georgian (???????)"},
+                {"id": "grc", "text": "Ancient Greek (????????)"},
+                {"id": "kor", "text": "Korean (???)"},
+                {"id": "slv", "text": "Slovenian (slovenšcina)"},
+                {"id": "sux", "text": "Sumerian (????)"},
+                {"id": "nob", "text": "Norwegian Bokmal (bokmål)"},
+                {"id": "rum", "text": "Romanian (limba româna)"},
+                {"id": "ara", "text": "Arabic (????????????)"},
+                {"id": "tha", "text": "Thai (???????)"},
+                {"id": "nor", "text": "Norwegian (norsk)"},
+                {"id": "lat", "text": "Latin (Lingua latina)"},
+                {"id": "dut", "text": "Dutch (Nederlands)"},
+                {"id": "ice", "text": "Icelandic (íslenska)"},
+                {"id": "lit", "text": "Lithuanian (lietuviu kalba)"},
+                {"id": "srp", "text": "Serbian (??????)"},
+                {"id": "baq", "text": "Basque (euskara)"},
+                {"id": "gle", "text": "Irish (Gaeilge)"},
+                {"id": "afr", "text": "Afrikaans (Afrikaans)"},
+                {"id": "heb", "text": "Hebrew (?????)"},
+                {"id": "dan", "text": "Danish (dansk)"},
+                {"id": "akk", "text": "Akkadian (????????)"},
+                {"id": "slo", "text": "Slovak (slovencina)"},
+                {"id": "nau", "text": "Nauru (dorerin Naoero)"},
+                {"id": "est", "text": "Estonian (eesti keel)"},
+                {"id": "vie", "text": "Vietnamese (Ti?ng Vi?t)"},
+                {"id": "bel", "text": "Belarusian (?????????? ????)"},
+                {"id": "glg", "text": "Galician (galego)"},
+                {"id": "ota", "text": "Ottoman Turkish (???? ??????)"},
+                {"id": "per", "text": "Persian (?????)"}
+            ]},
     ]
 }
 

--- a/server/preprocessing/other-scripts/summarize.R
+++ b/server/preprocessing/other-scripts/summarize.R
@@ -5,10 +5,16 @@ SplitTokenizer <- function(x) {
   return(tokens)
 }
 
+TypeCountTokenizer <- function(x) {
+  tokens = unlist(lapply(strsplit(words(x), split=";"), paste), use.names = FALSE)
+  tokens = unlist(lapply(tokens, gsub, pattern='[[:punct:]]', replacement=""))
+  return(tokens)
+}
+
 trim <- function (x) gsub("^\\s+|\\s+$", "", x)
 
 
-filter_out <- function(ngrams, stops){
+prune_ngrams <- function(ngrams, stops){
   tokens = mapply(strsplit, ngrams, split=" |;")
   tokens = mapply(strsplit, tokens, split="_")
   tokens = lapply(tokens, function(y){
@@ -149,14 +155,14 @@ fill_empty_areatitles <- function(cluster_labels, metadata) {
 
 get_title_ngrams <- function(titles, stops) {
   # for ngrams: we have to collapse with "_" or else tokenizers will split ngrams again at that point and we'll be left with unigrams
-  titles_bigrams = lapply(lapply(titles, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split=" ")), 2), paste, collapse="_"))), paste, collapse=" ")
-  titles_bigrams = filter_out(titles_bigrams, stops)
-  titles_trigrams = lapply(lapply(titles, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split=" ")), 3), paste, collapse="_"))), paste, collapse=" ")
-  titles_trigrams = filter_out(titles_trigrams, stops)
+  titles_bigrams = lapply(lapply(titles, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split = " ")), 2), paste, collapse  = "_"))), paste, collapse = " ")
+  titles_bigrams = prune_ngrams(titles_bigrams, stops)
+  titles_trigrams = lapply(lapply(titles, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split = " ")), 3), paste, collapse = "_"))), paste, collapse = " ")
+  titles_trigrams = prune_ngrams(titles_trigrams, stops)
   #titles_quadgrams = lapply(lapply(titles, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split=" ")), 4), paste, collapse="_"))), paste, collapse=" ")
-  #titles_quadgrams = filter_out(titles_quadgrams, stops)
+  #titles_quadgrams = prune_ngrams(titles_quadgrams, stops)
   #titles_fivegrams = lapply(lapply(titles, function(x)unlist(lapply(ngrams(unlist(strsplit(x, split=" ")), 5), paste, collapse="_"))), paste, collapse=" ")
-  #titles_fivegrams = filter_out(titles_fivegrams, stops)
+  #titles_fivegrams = prune_ngrams(titles_fivegrams, stops)
   return(list("bigrams" = titles_bigrams, "trigrams" = titles_trigrams))
 }
 
@@ -186,6 +192,6 @@ filter_out_nested_ngrams <- function(top_ngrams, top_n) {
 
 
 get_type_counts <- function(corpus) {
-  type_counts = apply(TermDocumentMatrix(corpus, control=list(tokenize=SplitTokenizer, tolower = FALSE)), 1, sum)
+  type_counts = apply(TermDocumentMatrix(corpus, control=list(tokenize=TypeCountTokenizer, tolower = FALSE)), 1, sum)
   return(type_counts)
 }


### PR DESCRIPTION
Irons out implementation problems in bubble-title generation: type counts used for identifying original casing are now created in a cleaner way.