### PR TITLE
removed lang_id from BASE params; robustified lang_id mapping

### DIFF
--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -57,7 +57,7 @@ get_papers <- function(query, params, limit=100,
   # language query field flag
   # CHANGE TO MORE LANGUAGES!!! look up dclang specifications
   lang_id <- params$lang_id
-  if (lang_id %in% names(valid_langs)) {
+  if (!is.null(valid_langs$lang_id)) {
     lang_query <- paste0("dclang:", lang_id)
     } else {
     lang_query <- ""

--- a/server/preprocessing/other-scripts/text_similarity.R
+++ b/server/preprocessing/other-scripts/text_similarity.R
@@ -68,7 +68,7 @@ if(!is.null(params_file) && !is.na(params_file)) {
   params <- NULL
 }
 
-if ('lang_id' %in% names(params)){
+if (!is.null(params$lang_id)) {
     lang_id <- params$lang_id
   } else {
     lang_id <- 'all'

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -69,10 +69,10 @@ get_api_lang <- function(lang_id, valid_langs, api) {
     }
   if (lang_id == 'all'){
     LANGUAGE <- 'english'
-    } else if (lang_id %in% names(valid_langs)){
-      LANGUAGE <- unlist(unname(valid_langs[lang_id]))
-    } else {
-      LANGUAGE <- 'english'
-    }
+  } else if (!is.null(valid_langs$lang_id)){
+    LANGUAGE <- valid_langs$lang_id
+  } else {
+    LANGUAGE <- 'english'
+  }
   return (list(lang_id = lang_id, name = LANGUAGE))
 }

--- a/server/services/searchBASE.php
+++ b/server/services/searchBASE.php
@@ -11,7 +11,7 @@ $dirty_query = library\CommUtils::getParameter($_POST, "q");
 
 $post_params = $_POST;
 
-$result = search("base", $dirty_query, $post_params, array("from", "to", "document_types", "sorting", "lang_id"), ";", null);
+$result = search("base", $dirty_query, $post_params, array("from", "to", "document_types", "sorting"), ";", null);
 
 echo $result
 


### PR DESCRIPTION
This PR removes the previously introduced but currently unused parameter lang_id from BASE.
* lang_id removed from searchBASE.php -> This for the moment restores compatiliby with legacy map-id generation
* the lang_id validation function in text_similarity and base.R have been robustified. the if-check for parameter presence now reliably returns a boolean value
* fallback is still all/english