### PR TITLE
Linkedcat backend

### DIFF
--- a/examples/linkedcat/index.html
+++ b/examples/linkedcat/index.html
@@ -27,6 +27,10 @@
             <input style="height:26px; vertical-align: middle;" type="text" name="q" size="61" required>
             <button type="submit" class="btn" style="background-color: #2856a3; color: white; width:10%; vertical-align: middle;">suchen</button>
             <div id="filter-container"></div>
+            <select name="exclude_content_type[]" multiple="multiple" style="display:none">
+                <option value="Mitgliederverzeichnis" selected>Mitgliederverzeichnis</option>
+                <option value="Bibliografie" selected>Bibliografie</option>
+            </select>
         </form>
     </div>
     <div id="progress" style="max-width:600px; margin: 0px auto;">

--- a/examples/linkedcat/search.js
+++ b/examples/linkedcat/search.js
@@ -38,7 +38,7 @@ $("#searchform").validate({
 });
 
 var doSubmit = function (data, newWindow, callback) {
-  data += "&today=" + new Date().toLocaleDateString("en-US");
+  data += "&today=" + new Date().toLocaleDateString("en-US") + "&include_content_type[]=";
 
   var openInNewWindow= function(data) {
     if (data.status === "success") {

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -69,8 +69,7 @@ get_papers <- function(query, params, limit=100) {
   text = data.frame(matrix(nrow=nrow(metadata)))
   text$id = metadata$id
   # Add all keywords, including classification to text
-  text$content = paste(metadata$title_str, metadata$subtitle_str,
-                       metadata$keywords_str, metadata$maintitle_str,
+  text$content = paste(metadata$keywords, metadata$maintitle,
                        metadata$paper_abstract,
                        sep = " ")
 

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -56,9 +56,9 @@ get_papers <- function(query, params, limit=100) {
   metadata[is.na(metadata)] <- ""
   metadata$subject <- metadata$keywords
   metadata$subject_orig <- metadata$subject
-  metadata$paper_abstract <- if ("ocrtext" %in% names(metadata)) metadata$ocrtext else ""
-  metadata$authors <- metadata$author_str
-  metadata$title <- metadata$maintitle_str
+  metadata$paper_abstract <- if ("ocrtext_good" %in% names(metadata)) metadata$ocrtext_good else ""
+  metadata$authors <- metadata$author100_a
+  metadata$title <- metadata$host_label
   metadata$year <- metadata$pubyear
   metadata$readers <- 0
   metadata$url <- "" # needs fix

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -54,7 +54,7 @@ get_papers <- function(query, params, limit=100) {
   # make results dataframe
   metadata <- data.frame(res)
   metadata[is.na(metadata)] <- ""
-  metadata$subject <- metadata$keywords
+  metadata$subject <- metadata$tags
   metadata$subject_orig <- metadata$subject
   metadata$paper_abstract <- if ("ocrtext_good" %in% names(metadata)) metadata$ocrtext_good else ""
   metadata$authors <- metadata$author100_a

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -106,7 +106,7 @@ build_query <- function(query, params, limit){
     temp <- paste0("-content_type_a:", ct)
     fq <- c(fq, temp)
   }
-  if (length(params$include_content_type) > 0) {
+  if (!params$include_content_type == 'all') {
     temp <- paste0("content_type_a:(",
                    paste0(params$include_content_type, collapse = " OR "),
                    ")")

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -85,10 +85,21 @@ get_papers <- function(query, params, limit=100) {
 }
 
 build_query <- function(query, params, limit){
-  q_fields = c('maintitle', 'keywords', 'ocrtext', 'author', 'host', 'ddc')
-  q = paste(paste(q_fields, query, sep = ":"), collapse = " ")
-  pubyear = paste0("pub_year:", "[", params$from, " TO ", params$to, "]")
-  q_params <- list(q = q, rows = limit, fq = pubyear)
+  q_fields <- c('maintitle', 'keywords', 'ocrtext', 'author', 'host', 'ddc')
+  q <- paste(paste(q_fields, query, sep = ":"), collapse = " ")
+  q_params <- list(q = q, rows = limit)
+
+  # additional filter params
+  fq <- list()
+  pub_year <- paste0("pub_year:", "[", params$from, " TO ", params$to, "]")
+  fq <- c(fq, pub_year)
+  for (ct in params$exclude_content_type) {
+    temp <- paste0("-content_type_a:", ct)
+    fq <- c(fq, temp)
+  }
+
+  q_params$fq <- fq
+
   return(q_params)
 }
 

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -85,9 +85,19 @@ get_papers <- function(query, params, limit=100) {
 }
 
 build_query <- function(query, params, limit){
+  # fields to query in
   q_fields <- c('maintitle', 'keywords', 'ocrtext', 'author', 'host', 'ddc')
+  # fields to return
+  r_fields <- c('id', 'idnr',
+                'content_type_a', 'content_type_2',
+                'main_title', 'subtitle', 'pub_year',
+                'host_label', 'host_maintitle', 'host_pubplace', 'host_pubyear',
+                'author100_a', 'author100_d', 'author100_0', 'author100_4',
+                'ddc_a', 'ddc_2', 'bkl_a',
+                'keyword_a', 'tags', 'category', 'bib', 'language_code',
+                'ocrtext_good', 'ocrtext')
   q <- paste(paste(q_fields, query, sep = ":"), collapse = " ")
-  q_params <- list(q = q, rows = limit)
+  q_params <- list(q = q, rows = limit, fl = r_fields)
 
   # additional filter params
   fq <- list()
@@ -99,7 +109,7 @@ build_query <- function(query, params, limit){
   }
   if (length(params$include_content_type) > 0) {
     temp <- paste0("content_type_a:(",
-                   paste0(params$include_content_type, collapse=" OR "),
+                   paste0(params$include_content_type, collapse = " OR "),
                    ")")
     fq <- c(fq, temp)
   }

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -97,9 +97,14 @@ build_query <- function(query, params, limit){
     temp <- paste0("-content_type_a:", ct)
     fq <- c(fq, temp)
   }
-
+  if (length(params$include_content_type) > 0) {
+    temp <- paste0("content_type_a:(",
+                   paste0(params$include_content_type, collapse=" OR "),
+                   ")")
+    fq <- c(fq, temp)
+  }
   q_params$fq <- fq
-
+  # end adding filter params
   return(q_params)
 }
 

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -85,10 +85,11 @@ get_papers <- function(query, params, limit=100) {
 }
 
 build_query <- function(query, params, limit){
-  fields = c('maintitle', 'keywords', 'ocrtext', 'author', 'host', 'ddc')
-  q = paste(paste(fields, query, sep = ":"), collapse = " ")
-  pubyear = paste0("pubyear:", "[", params$from, " TO ", params$to, "]")
-  return(list(q = q, rows = limit, fq = pubyear))
+  q_fields = c('maintitle', 'keywords', 'ocrtext', 'author', 'host', 'ddc')
+  q = paste(paste(q_fields, query, sep = ":"), collapse = " ")
+  pubyear = paste0("pub_year:", "[", params$from, " TO ", params$to, "]")
+  q_params <- list(q = q, rows = limit, fq = pubyear)
+  return(q_params)
 }
 
 

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -54,9 +54,9 @@ get_papers <- function(query, params, limit=100) {
   # make results dataframe
   metadata <- data.frame(res)
   metadata[is.na(metadata)] <- ""
-  metadata$subject <- metadata$tags
+  metadata$subject <- if (!is.null(metadata$tags)) metadata$tags else ""
   metadata$subject_orig <- metadata$subject
-  metadata$paper_abstract <- if ("ocrtext_good" %in% names(metadata)) metadata$ocrtext_good else ""
+  metadata$paper_abstract <- if (!is.null(metadata$ocrtext_good)) metadata$ocrtext_good else ""
   metadata$authors <- metadata$author100_a
   metadata$title <- metadata$host_label
   metadata$year <- metadata$pubyear
@@ -69,8 +69,7 @@ get_papers <- function(query, params, limit=100) {
   text = data.frame(matrix(nrow=nrow(metadata)))
   text$id = metadata$id
   # Add all keywords, including classification to text
-  text$content = paste(metadata$keywords, metadata$maintitle,
-                       metadata$paper_abstract,
+  text$content = paste(metadata$paper_abstract,
                        sep = " ")
 
 

--- a/server/preprocessing/other-scripts/preprocess.R
+++ b/server/preprocessing/other-scripts/preprocess.R
@@ -75,7 +75,6 @@ replace_keywords_if_empty <- function(metadata, stops) {
 
   missing_subjects = which(lapply(metadata$subject, function(x) {nchar(x)}) <= 1)
   candidates = mapply(paste, metadata$title[missing_subjects], metadata$paper_abstract[missing_subjects])
-  candidates = mapply(conditional_lowercase, candidates, metadata$lang_detected[missing_subjects])
   candidates = lapply(candidates, function(x)paste(removeWords(x, stops), collapse=""))
   candidates = lapply(candidates, function(x) {gsub("[^[:alpha:]]", " ", x)})
   candidates = lapply(candidates, function(x) {gsub(" +", " ", x)})

--- a/server/preprocessing/other-scripts/summarize.R
+++ b/server/preprocessing/other-scripts/summarize.R
@@ -99,7 +99,6 @@ get_cluster_corpus <- function(clusters, metadata, stops, taxonomy_separator) {
 
     titles = lapply(titles, function(x) {gsub("[^[:alpha:]]", " ", x)})
     titles = lapply(titles, gsub, pattern="\\s+", replacement=" ")
-    titles = mapply(conditional_lowercase, titles, langs)
     title_ngrams <- get_title_ngrams(titles, stops)
     titles = lapply(titles, function(x) {removeWords(x, stops)})
 

--- a/server/preprocessing/other-scripts/test/linkedcat-test.R
+++ b/server/preprocessing/other-scripts/test/linkedcat-test.R
@@ -53,7 +53,6 @@ tryCatch({
                            lang = LANGUAGE,
                            add_stop_words = ADDITIONAL_STOP_WORDS,
                            testing=TRUE, list_size=-1)
-  
 }, error=function(err){
   tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
 })

--- a/server/preprocessing/other-scripts/test/params_linkedcat.json
+++ b/server/preprocessing/other-scripts/test/params_linkedcat.json
@@ -2,5 +2,5 @@
   "from":"1847",
   "to":"1918",
   "exclude_content_type": ["Mitgliederverzeichnis", "Bibliografie"],
-  "include_content_type": []
+  "include_content_type": "all"
 }

--- a/server/preprocessing/other-scripts/test/params_linkedcat.json
+++ b/server/preprocessing/other-scripts/test/params_linkedcat.json
@@ -1,4 +1,5 @@
 {
   "from":"1847",
-  "to":"1918"
+  "to":"1918",
+  "exclude_content_type": ["Mitgliederverzeichnis", "Bibliografie"]
 }

--- a/server/preprocessing/other-scripts/test/params_linkedcat.json
+++ b/server/preprocessing/other-scripts/test/params_linkedcat.json
@@ -2,5 +2,5 @@
   "from":"1847",
   "to":"1918",
   "exclude_content_type": ["Mitgliederverzeichnis", "Bibliografie"],
-  "include_content_type": ["Briefsammlung"]
+  "include_content_type": []
 }

--- a/server/preprocessing/other-scripts/test/params_linkedcat.json
+++ b/server/preprocessing/other-scripts/test/params_linkedcat.json
@@ -1,5 +1,6 @@
 {
   "from":"1847",
   "to":"1918",
-  "exclude_content_type": ["Mitgliederverzeichnis", "Bibliografie"]
+  "exclude_content_type": ["Mitgliederverzeichnis", "Bibliografie"],
+  "include_content_type": ["Briefsammlung"]
 }

--- a/server/services/searchLinkedCat.php
+++ b/server/services/searchLinkedCat.php
@@ -11,7 +11,7 @@ $dirty_query = library\CommUtils::getParameter($_POST, "q");
 
 $post_params = $_POST;
 
-$result = search("linkedcat", $dirty_query, $post_params, array("from", "to"), ";", null);
+$result = search("linkedcat", $dirty_query, $post_params, array("from", "to", "exclude_content_type", "include_content_type"), ";", null);
 
 echo $result
 


### PR DESCRIPTION
Regarding input data:
* the used fields have been adapted to the new SOLR fields
* the text_content used for text_similarity has been reduced to the ocrtext only, since the other fields currently rarely contribute valuable information in that regard

Regarding query functionality:
* the return fields have been specified
* the pub_year filter has been updated to the new SOLR field
* two filter params haven added for inclusion or exclusion of document types (`content_type_a`), queries also work if none of them are specified

Regarding summarization:
* now-defunct conditional lowercasing has been removed as this functionality is superceded by the keyword case-matching

Regarding interaction with external queries:
* params are now expected to include `exclude_content_type` and `include_content_type`, they can also be empty lists (see params_linkedcat.json and searchLinkedCat.php)
* this needs to be reflected in the api-caller before the full pipeline can be tested again