### PR TITLE
Error handling

### DIFF
--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -43,11 +43,13 @@ LANGUAGE <- get_api_lang(lang_id, valid_langs, service)
 ADDITIONAL_STOP_WORDS = LANGUAGE$name
 
 #start.time <- Sys.time()
-
+failed <- list()
 tryCatch({
   input_data = get_papers(query, params, limit=120)
 }, error=function(err){
   tslog$error(gsub("\n", " ", paste("Query failed", service, query, paste(params, collapse=" "), err, sep="||")))
+  failed$query <<- query
+  failed$query_reason <<- err$message
 })
 
 #end.time <- Sys.time()
@@ -59,9 +61,12 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
 }, error=function(err){
   tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
-  output <- detect_error(query, err)
-  output$msg <- "query failed"
-  output_json <<- toJSON(output, auto_unbox = TRUE)
+  failed$query <<- query
+  failed$processing_reason <<- err$message
 })
+
+if (!exists('output_json')) {
+  output_json <- detect_error(failed)
+}
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -5,9 +5,10 @@ library(rstudioapi)
 options(warn=1)
 
 wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
+Sys.unsetenv("HEADSTART_LOGFILE")
 setwd(wd) #Don't forget to set your working directory
 
-query <- "education" #args[2]
+query <- "latest research topics in parallel programming" #args[2]
 service <- "base"
 params <- NULL
 params_file <- "params_base.json"
@@ -57,7 +58,10 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          lang=LANGUAGE$name,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
+  output <- detect_error(query, err)
+  output$msg <- "query failed"
+  output_json <<- toJSON(output, auto_unbox = TRUE)
 })
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -43,7 +43,7 @@ LANGUAGE <- get_api_lang(lang_id, valid_langs, service)
 ADDITIONAL_STOP_WORDS = LANGUAGE$name
 
 #start.time <- Sys.time()
-failed <- list()
+failed <- list(params=params)
 tryCatch({
   input_data = get_papers(query, params, limit=120)
 }, error=function(err){

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -5,10 +5,9 @@ library(rstudioapi)
 options(warn=1)
 
 wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
-Sys.unsetenv("HEADSTART_LOGFILE")
 setwd(wd) #Don't forget to set your working directory
 
-query <- "latest research topics in parallel programming" #args[2]
+query <- "education" #args[2]
 service <- "base"
 params <- NULL
 params_file <- "params_base.json"

--- a/server/preprocessing/other-scripts/test/pubmed-test.R
+++ b/server/preprocessing/other-scripts/test/pubmed-test.R
@@ -42,11 +42,13 @@ LANGUAGE <- get_api_lang(lang_id, valid_langs, service)
 ADDITIONAL_STOP_WORDS = LANGUAGE$name
 
 #start.time <- Sys.time()
-
+failed <- list(params=params)
 tryCatch({
   input_data = get_papers(query, params)
 }, error=function(err){
   tslog$error(gsub("\n", " ", paste("Query failed", service, query, paste(params, collapse=" "), err, sep="||")))
+  failed$query <<- query
+  failed$query_reason <<- err$message
 })
 
 #end.time <- Sys.time()
@@ -58,6 +60,12 @@ output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
 }, error=function(err){
 tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
+  failed$query <<- query
+  failed$query_reason <<- err$message
 })
+
+if (!exists('output_json')) {
+  output_json <- detect_error(failed)
+}
 
 print(output_json)

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -86,12 +86,13 @@ detect_error <- function(failed) {
     output$message <- failed$query_reason
   }
   if (length(unlist(strsplit(failed$query, " "))) >= 4) {
-    output$reason <- 'query length'
+    output$reason <- 'probably query length'
     output$message <- failed$query_reason
   }
-  if (difftime(failed$params$to, failed$params$from) <= 30) {
+  if (difftime(failed$params$to, failed$params$from) <= 60) {
     output$reason <- 'probably timeframe too short'
     output$message <- failed$query_reason
   }
+  output$status <- 'error'
   return(toJSON(output, auto_unbox = TRUE))
 }

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -76,3 +76,13 @@ get_api_lang <- function(lang_id, valid_langs, api) {
     }
   return (list(lang_id = lang_id, name = LANGUAGE))
 }
+
+
+detect_error <- function(query, err) {
+  if (length(unlist(strsplit(query, " "))) >= 5) {
+    return(list(reason='query length'))
+  }
+  if (err$message == "Not enough papers for clustering, N < 2.") {
+    return(list(reason='query specificity'))
+  }
+}

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -89,7 +89,9 @@ detect_error <- function(failed) {
     output$reason <- 'probably query length'
     output$message <- failed$query_reason
   }
-  if (difftime(failed$params$to, failed$params$from) <= 60) {
+  if (!is.null(failed$params$to) &&
+      !is.null(failed$params$from) &&
+      difftime(failed$params$to, failed$params$from) <= 60) {
     output$reason <- 'probably timeframe too short'
     output$message <- failed$query_reason
   }

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -80,12 +80,17 @@ get_api_lang <- function(lang_id, valid_langs, api) {
 
 detect_error <- function(failed) {
   output <- list()
-  if (length(unlist(strsplit(failed$query, " "))) >= 4) {
-    output$reason <- 'query length'
-  }
   if (length(unlist(strsplit(failed$query, " "))) < 4 &&
       failed$query_reason == "No results retrieved.") {
     output$reason <- 'probably typo'
+    output$message <- failed$query_reason
+  }
+  if (length(unlist(strsplit(failed$query, " "))) >= 4) {
+    output$reason <- 'query length'
+    output$message <- failed$query_reason
+  }
+  if (difftime(failed$params$to, failed$params$from) <= 30) {
+    output$reason <- 'probably timeframe too short'
     output$message <- failed$query_reason
   }
   return(toJSON(output, auto_unbox = TRUE))

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -78,11 +78,15 @@ get_api_lang <- function(lang_id, valid_langs, api) {
 }
 
 
-detect_error <- function(query, err) {
-  if (length(unlist(strsplit(query, " "))) >= 5) {
-    return(list(reason='query length'))
+detect_error <- function(failed) {
+  output <- list()
+  if (length(unlist(strsplit(failed$query, " "))) >= 4) {
+    output$reason <- 'query length'
   }
-  if (err$message == "Not enough papers for clustering, N < 2.") {
-    return(list(reason='query specificity'))
+  if (length(unlist(strsplit(failed$query, " "))) < 4 &&
+      failed$query_reason == "No results retrieved.") {
+    output$reason <- 'probably typo'
+    output$message <- failed$query_reason
   }
+  return(toJSON(output, auto_unbox = TRUE))
 }

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -80,21 +80,20 @@ get_api_lang <- function(lang_id, valid_langs, api) {
 
 detect_error <- function(failed) {
   output <- list()
-  if (length(unlist(strsplit(failed$query, " "))) < 4 &&
-      failed$query_reason == "No results retrieved.") {
-    output$reason <- 'probably typo'
-    output$message <- failed$query_reason
-  }
-  if (length(unlist(strsplit(failed$query, " "))) >= 4) {
-    output$reason <- 'probably query length'
-    output$message <- failed$query_reason
+  reason <- list()
+  # first identify criteria
+  if (length(unlist(strsplit(failed$query, " "))) < 4) {
+    reason <- c(reason, 'typo', 'too specific')
+  } else {
+    reason <- c(reason, 'query length', 'too specific')
   }
   if (!is.null(failed$params$to) &&
       !is.null(failed$params$from) &&
       difftime(failed$params$to, failed$params$from) <= 60) {
-    output$reason <- 'probably timeframe too short'
-    output$message <- failed$query_reason
+    reason <- c(reason, 'timeframe too short')
   }
+  # then return them as json list
+  output$reason <- reason
   output$status <- 'error'
   return(toJSON(output, auto_unbox = TRUE))
 }

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -85,7 +85,7 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
     $result = json_decode($output_json, true);
 
     if ($result["status"] == "error") {
-        return json_encode($output_json);
+        return json_encode($result);
     }
 
     $input_json = json_encode(utf8_converter($result));

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -55,7 +55,7 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
     $settings = $ini_array["general"];
 
     $params_json = packParamsJSON($param_types, $post_params);
-    
+
     $params_for_id_creation = ($params_for_id === null)?($params_json):(packParamsJSON($params_for_id, $post_params));
 
     $unique_id = $persistence->createID(array($query, $params_for_id_creation));
@@ -82,10 +82,8 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
     $output_json = end($output);
     $output_json = mb_convert_encoding($output_json, "UTF-8");
 
-    if (!library\Toolkit::isJSON($output_json) || $output_json == "null" || $output_json == null) {
-
-        echo json_encode(array("status" => "error"));;
-        return;
+    if ($output_json["status"] == "error") {
+        return json_encode($output_json);
     }
 
     $result = json_decode($output_json, true);

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -83,6 +83,7 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
     $output_json = mb_convert_encoding($output_json, "UTF-8");
 
     if (!library\Toolkit::isJSON($output_json) || $output_json == "null" || $output_json == null) {
+
         echo json_encode(array("status" => "error"));;
         return;
     }

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -82,6 +82,11 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
     $output_json = end($output);
     $output_json = mb_convert_encoding($output_json, "UTF-8");
 
+    if (!library\Toolkit::isJSON($output_json) || $output_json == "null" || $output_json == null) {
+        echo json_encode(array("status" => "error"));;
+        return;
+    }
+
     $result = json_decode($output_json, true);
 
     if ($result["status"] == "error") {

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -82,11 +82,11 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
     $output_json = end($output);
     $output_json = mb_convert_encoding($output_json, "UTF-8");
 
-    if ($output_json["status"] == "error") {
+    $result = json_decode($output_json, true);
+
+    if ($result["status"] == "error") {
         return json_encode($output_json);
     }
-
-    $result = json_decode($output_json, true);
 
     $input_json = json_encode(utf8_converter($result));
     $input_json = preg_replace("/\<U\+(.*?)>/", "&#x$1;", $input_json);


### PR DESCRIPTION
So far, when the backend processing fails (either due to input data or a processing problem), no output is returned, and we communicate a general purpose message to the user. This PR implements basic heuristics to detect the most common reasons for failing queries/map generation. This allows to give users better feedback about why queries failed, and allows us to give users suggestions for more successful queries.

Process:
* Instead of returning nothing, the R-backend now runs an error detection heuristic (utils.R, detect_error) and returns a json, for example `{"reason":"probably timeframe too short","message":"No input data found.","status":"error"}`
* The search.php service has been modified to check the output of the call to the R-backend, if the json contains a `status == error`, it will pass this json through, if not, it will continue as usual
* If for some reason the R-backend fails totally (e.g. missing packages or other deployment problems), the current behavior remains
* the POST to searchBASE.php/searchPubmed.php now receives this json as response, and the `reason` field can be used to select and display an appropriate message
* The errors have following hierarchy: short timeframe > query length > typo
* The threshold for query length (4 words) is based on the median length of failing queries (5 words) minus 1, the threshold for time frame length (60 days) is a guesstimate, but covers the option of most recent month

Examples:
* on PubMed: `computer science machine learning 2018-11-25 2018-11-25` results in `{"reason":"probably timeframe too short","message":"No input data found.","status":"error"}`
* on BASE: `natural language processing in indonesian literature 1665-01-01 2017-08-19` results in `{"reason":"probably query length","status":"error"}`
* on BASE: `naturall language processsing 1665-01-01 2018-11-24` results in `{"reason":"probably typo","status":"error"}`