### PR TITLE
Linkedcat backend

### DIFF
--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -73,6 +73,8 @@ get_papers <- function(query, params, limit=100) {
   metadata$oa_state <- 1
   metadata$subject_orig = metadata$subject
   metadata$relevance = c(nrow(metadata):1)
+  metadata$bkl_caption = unlist(lapply(metadata$bkl_caption, function(x) gsub(",", "; ", x)))
+  metadata$bkl_top_caption = if (!is.null(metadata$bkl_top_caption)) unlist(lapply(metadata$bkl_top_caption, function(x) gsub(",", "; ", x))) else ""
 
   text = data.frame(matrix(nrow=nrow(metadata)))
   text$id = metadata$id

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -60,7 +60,7 @@ get_papers <- function(query, params, limit=100) {
   metadata <- merge(x = metadata, y = highlights, by.x='id', by.y='id')
 
   metadata[is.na(metadata)] <- ""
-  metadata$subject <- if (!is.null(metadata$keyword_a)) unlist(lapply(metadata$keyword_a, function(x) {if (nchar(x)>0) gsub(", ,", ",", paste(unlist(strsplit(x, ",")), collapse=", ")) else ""})) else ""
+  metadata$subject <- if (!is.null(metadata$keyword_a)) unlist(lapply(metadata$keyword_a, function(x) {if (nchar(x)>0) gsub("; ;", ";", paste(unlist(strsplit(x, ",")), collapse="; ")) else ""})) else ""
   metadata$authors <- metadata$author100_a
   metadata$author_date <- metadata$author100_d
   metadata$title <- if (!is.null(metadata$main_title)) metadata$main_title else ""

--- a/server/preprocessing/other-scripts/summarize.R
+++ b/server/preprocessing/other-scripts/summarize.R
@@ -135,22 +135,27 @@ get_top_names <- function(tfidf_top, top_n, stops) {
 }
 
 another_prune_ngrams <- function(ngrams, stops){
+  # filter out stopwords from start or stop of ngrams
   tokens <- unname(unlist(ngrams))
+  # split ngrams
   tokens = lapply(tokens, strsplit, split="_")
+  # check if first token of ngrams in stopword list
   tokens = lapply(tokens, function(y){
                           Filter(function(x){
                                       !any(grepl(x[1], c(stops)))
                                             }, y)})
+  # check if last token of ngrams in stopword list
   tokens = lapply(tokens, function(y){
                           Filter(function(x){
                                       !any(grepl(tail(x,1), c(stops)))
                                             }, y)})
-  if (length(tokens) > 1) {
-    tokens = lapply(tokens, function(y){
-                            Filter(function(x){
-                                        !(x[1]==tail(x,1))
-                                          }, y)})
-  }
+  # check that first token is not the same as the last token
+  tokens = lapply(tokens, function(y){
+                    if(length(y) > 1) {
+                          Filter(function(x){
+                                      !(x[1]==tail(x,1))
+                          }, y)}
+                    else y})
   tokens = lapply(tokens, function(y){Filter(function(x){length(x)>=1},y)})
   empties = which(lapply(tokens, length)==0)
   tokens[c(empties)] = list("")

--- a/server/preprocessing/other-scripts/summarize.R
+++ b/server/preprocessing/other-scripts/summarize.R
@@ -145,10 +145,12 @@ another_prune_ngrams <- function(ngrams, stops){
                           Filter(function(x){
                                       !any(grepl(tail(x,1), c(stops)))
                                             }, y)})
-  tokens = lapply(tokens, function(y){
-                          Filter(function(x){
-                                      !(x[1]==tail(x,1))
-                                        }, y)})
+  if (length(tokens) > 1) {
+    tokens = lapply(tokens, function(y){
+                            Filter(function(x){
+                                        !(x[1]==tail(x,1))
+                                          }, y)})
+  }
   tokens = lapply(tokens, function(y){Filter(function(x){length(x)>=1},y)})
   empties = which(lapply(tokens, length)==0)
   tokens[c(empties)] = list("")


### PR DESCRIPTION
This PR fixes bad behaviour in area title generation at the step of stopword-filtering from area titles. The problem occured in cases where summary candidates consist only of single tokens: If all top_n candidates each consist of single tokens, all would get filtered out erroneously, resulting in empty area titles for a paper. This in turn would lead to area title substitution from keywords.
This has been fixed by checking for candidate length > 1 and conditionally apply the filter.
Additionally, keyword separators for linkedcat-metadata have been changed from ',' to ';'.

This PR is opened for review, but since this occurs in a stage of the pipeline that concerns all APIs I'd like to run a few other tests first.