### PR TITLE
Linkedcat backend

### DIFF
--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -71,7 +71,7 @@ get_api_lang <- function(lang_id, valid_langs, api) {
   } else {
     LANGUAGE <- 'english'
   }
-  if (api == 'linkedcat') {
+  if (api == 'linkedcat' || api == 'linkedcat_authorview') {
       lang_id <- 'ger'
       LANGUAGE <- 'german'
     }

--- a/server/preprocessing/resources/german.stop
+++ b/server/preprocessing/resources/german.stop
@@ -185,6 +185,7 @@ sollte
 sondern
 sonst
 über
+ueber
 um
 und
 uns


### PR DESCRIPTION
This PR fixes stopwords appearing in bubble titles in the linkedcat-authorview by correctly assigning it to German. One stopword was added.