### PR TITLE
Fix 1contentmaps

### DIFF
--- a/server/preprocessing/other-scripts/cluster.R
+++ b/server/preprocessing/other-scripts/cluster.R
@@ -9,76 +9,81 @@ get_cut_off <- function(css_cluster, attempt=1){
 }
 
 create_clusters <- function(distance_matrix, max_clusters=-1, method="ward.D") {
-  if(nrow(distance_matrix) < 2){
-    stop("Not enough papers for clustering, N < 2.")
-  }
-  # Perform clustering, use elbow to determine a good number of clusters
-  css_cluster <- css.hclust(distance_matrix, hclust.FUN.MoreArgs=list(method="ward.D"))
-  num_clusters <- NA
-  num_clusters <-tryCatch({
-    cut_off <- elbow.batch(css_cluster)
-    num_clusters <- cut_off$k
-  }, error = function(err){
-    vclog$warn(err)
-    return (NA)
-  })
-  attempt <- 1
-  while(is.na(num_clusters)){
-    num_clusters <- tryCatch({
-      cut_off <- get_cut_off(css_cluster, attempt)
-      attempt <- attempt+1
-      cut_off$k
+  if (nrow(distance_matrix) < 2) {
+    warning("Not enough papers for clustering, N < 2.")
+    num_clusters <- 1
+    labels = labels(distance_matrix)
+    groups = 1
+    names(groups) <- labels
+    cluster <- NULL
+  } else {
+    # Perform clustering, use elbow to determine a good number of clusters
+    css_cluster <- css.hclust(distance_matrix, hclust.FUN.MoreArgs=list(method="ward.D"))
+    num_clusters <- NA
+    num_clusters <-tryCatch({
+      cut_off <- elbow.batch(css_cluster)
+      num_clusters <- cut_off$k
     }, error = function(err){
       vclog$warn(err)
       return (NA)
-      }
-    )
-  }
+    })
+    attempt <- 1
+    while(is.na(num_clusters)){
+      num_clusters <- tryCatch({
+        cut_off <- get_cut_off(css_cluster, attempt)
+        attempt <- attempt+1
+        cut_off$k
+      }, error = function(err){
+        vclog$warn(err)
+        return (NA)
+        }
+      )
+    }
 
-  num_items = nrow(distance_matrix)
+    num_items = nrow(distance_matrix)
 
-  if(!is.null(num_clusters) && max_clusters > -1 && num_clusters > max_clusters) {
-    num_clusters = MAX_CLUSTERS
+    if(!is.null(num_clusters) && max_clusters > -1 && num_clusters > max_clusters) {
+      num_clusters = MAX_CLUSTERS
 
-    if(num_items >= 150) {
-      vclog$warn("High content number, increasing max_k.")
-      if(num_items >= 150 && num_items < 200) {
-        num_clusters = 16
-      } else if (num_items >= 200 && num_items < 300) {
-        num_clusters = 17
-      } else if (num_items >= 300 && num_items < 400) {
-        num_clusters = 18
-      } else if (num_items >= 400 && num_items < 500) {
-        num_clusters = 19
-      } else if (num_items >= 500) {
-        num_clusters = 20
+      if(num_items >= 150) {
+        vclog$warn("High content number, increasing max_k.")
+        if(num_items >= 150 && num_items < 200) {
+          num_clusters = 16
+        } else if (num_items >= 200 && num_items < 300) {
+          num_clusters = 17
+        } else if (num_items >= 300 && num_items < 400) {
+          num_clusters = 18
+        } else if (num_items >= 400 && num_items < 500) {
+          num_clusters = 19
+        } else if (num_items >= 500) {
+          num_clusters = 20
+        }
       }
     }
+
+    if(num_items <= 30){
+      vclog$warn("Low content number, lowering max_k.")
+      num_clusters = round(sqrt(nrow(distance_matrix))) + 1
+    }
+
+    meta_cluster = attr(css_cluster,"meta")
+    cluster = meta_cluster$hclust.obj
+    labels = labels(distance_matrix)
+
+    groups <- cutree(cluster, k=num_clusters)
+
+    # NEEDS FIX
+    # if(exists("DEBUG") && DEBUG == TRUE) {
+    #   # Plot result of clustering to PDF file
+    #   pdf("clustering.pdf", width=19, height=12)
+    #   plot(cluster, labels=metadata$title, cex=0.6)
+    #   rect.hclust(cluster, k=num_clusters, border="red")
+    #   dev.off()
+    # }
+
+    vclog$info(paste("Number of Clusters:", num_clusters, sep=" "))
+    vclog$debug(paste("CutOff-Description:", attributes(cut_off)$description))
   }
-
-  if(num_items <= 30){
-    vclog$warn("Low content number, lowering max_k.")
-    num_clusters = round(sqrt(nrow(distance_matrix))) + 1
-  }
-
-  meta_cluster = attr(css_cluster,"meta")
-  cluster = meta_cluster$hclust.obj
-  labels = labels(distance_matrix)
-
-  groups <- cutree(cluster, k=num_clusters)
-
-  # NEEDS FIX
-  # if(exists("DEBUG") && DEBUG == TRUE) {
-  #   # Plot result of clustering to PDF file
-  #   pdf("clustering.pdf", width=19, height=12)
-  #   plot(cluster, labels=metadata$title, cex=0.6)
-  #   rect.hclust(cluster, k=num_clusters, border="red")
-  #   dev.off()
-  # }
-
-  vclog$info(paste("Number of Clusters:", num_clusters, sep=" "))
-  vclog$debug(paste("CutOff-Description:", attributes(cut_off)$description))
-
   clusters = list("labels"=labels, "cluster"=cluster, "groups"=groups, "num_clusters"=num_clusters)
   return(clusters)
 
@@ -90,15 +95,17 @@ get_ndms <- function(distance_matrix, mindim=2, maxdim=2, maxit=500) {
   # Perform non-metric multidimensional scaling
   # nm <- par.nmds(distance_matrix, mindim=mindim, maxdim=maxdim, maxit=maxit)
   # nm.nmin = nmds.min(nm)
-  if (nrow(distance_matrix) <= 2){
+  if (nrow(distance_matrix) <= 2) {
     points <- tryCatch({
       ord <- metaMDS(distance_matrix, k = 2, parallel = 3)
       points <- ord$points
     }, error=function(err){
-      points <- rbind(runif(nrow(distance_matrix), min=-1, max=0),
+      points <- cbind(runif(nrow(distance_matrix), min=-1, max=0),
                       runif(nrow(distance_matrix), min=0, max=1))
       return(points)
     })
+  } else if (nrow(distance_matrix) == 1) {
+    points <- cbind(0, 0)
   } else {
     ord <- metaMDS(distance_matrix, k = 2, parallel = 3)
     points <- ord$points

--- a/server/preprocessing/other-scripts/features.R
+++ b/server/preprocessing/other-scripts/features.R
@@ -43,6 +43,9 @@ create_tdm_matrix <- function(corpus, sparsity=1) {
 
 get_distance_matrix <- function(tdm_matrix, method = "cosine") {
   distance_matrix <- as.matrix(dist(tdm_matrix, method))
+  if (nrow(distance_matrix) == 0) {
+    colnames(distance_matrix) <- labels(tdm_matrix)$Docs
+  }
   return(distance_matrix)
 }
 


### PR DESCRIPTION
This PR makes generation of maps with one content item possible. For this three points in the pipeline had to be improved:
* Clustering would fail with one content item. Fallback data have been introduced that emulate a clustering outcome with 1 cluster containing 1 item in `create clusters` and `get_distance_matrix`
* Layout would fail, because the existing function could not correctly produce 2 dimensional coordinates for only 1 item. Fallback data structure was introduced in `get_nmds`

It has been tested with authors with only 1 paper in LinkedCat, and on BASE by shrinking the date range until only 1 paper was returned. Due to broader date indexing in Pubmed, so far no 1 paper map could be tested.