### PR TITLE
fixed area inconsistencies between bubble-titles and associated docs

### DIFF
--- a/server/preprocessing/other-scripts/linkedcat_authorview.R
+++ b/server/preprocessing/other-scripts/linkedcat_authorview.R
@@ -56,7 +56,7 @@ get_papers <- function(query, params, limit=100) {
   metadata <- data.frame(res$search)
 
   metadata[is.na(metadata)] <- ""
-  metadata$subject <- if (!is.null(metadata$keyword_a)) unlist(lapply(metadata$keyword_a, function(x) {if (nchar(x)>0) gsub(", ,", ",", paste(unlist(strsplit(x, ",")), collapse=", ")) else ""})) else ""
+  metadata$subject <- if (!is.null(metadata$keyword_a)) unlist(lapply(metadata$keyword_a, function(x) {if (nchar(x)>0) gsub("; ;", ";", paste(unlist(strsplit(x, ",")), collapse="; ")) else ""})) else ""
   metadata$authors <- metadata$author100_a
   metadata$author_date <- metadata$author100_d
   metadata$title <- if (!is.null(metadata$main_title)) metadata$main_title else ""
@@ -69,6 +69,8 @@ get_papers <- function(query, params, limit=100) {
   metadata$oa_state <- 1
   metadata$subject_orig = metadata$subject
   metadata$relevance = c(nrow(metadata):1)
+  metadata$bkl_caption = unlist(lapply(metadata$bkl_caption, function(x) gsub(",", "; ", x)))
+  metadata$bkl_top_caption = if (!is.null(metadata$bkl_top_caption)) unlist(lapply(metadata$bkl_top_caption, function(x) gsub(",", "; ", x))) else ""
 
   text = data.frame(matrix(nrow=nrow(metadata)))
   text$id = metadata$id


### PR DESCRIPTION
This PR implements the bugfixes from #335 that have been made to the linkedcat-backend also on the authorview-backend. The code diverged here, as a lot of the mapping functionality is shared, but duplicated in both APIs
A redesign and modularisation of functionalities may be advised.