### PR TITLE
robustified stopword filtering in bubble summarization

### DIFF
--- a/server/preprocessing/other-scripts/summarize.R
+++ b/server/preprocessing/other-scripts/summarize.R
@@ -19,11 +19,11 @@ prune_ngrams <- function(ngrams, stops){
   tokens = mapply(strsplit, tokens, split="_")
   tokens = lapply(tokens, function(y){
                           Filter(function(x){
-                                      !any(grepl(x[1], c(stops)))
+                                  if (x[1] != "") !any(stri_detect_fixed(stops, x[1]))
                                             }, y)})
   tokens = lapply(tokens, function(y){
                           Filter(function(x){
-                                      !any(grepl(tail(x,1), c(stops)))
+                                  if (tail(x,1) != "") !any(stri_detect_fixed(stops, tail(x,1)))
                                             }, y)})
   tokens = lapply(tokens, function(y){
                           Filter(function(x){
@@ -142,12 +142,12 @@ another_prune_ngrams <- function(ngrams, stops){
   # check if first token of ngrams in stopword list
   tokens = lapply(tokens, function(y){
                           Filter(function(x){
-                                      !any(grepl(x[1], c(stops)))
+                                  if (x[1] != "") !any(stri_detect_fixed(stops, x[1]))
                                             }, y)})
   # check if last token of ngrams in stopword list
   tokens = lapply(tokens, function(y){
                           Filter(function(x){
-                                      !any(grepl(tail(x,1), c(stops)))
+                                  if (tail(x,1) != "") !any(stri_detect_fixed(stops, tail(x,1)))
                                             }, y)})
   # check that first token is not the same as the last token
   tokens = lapply(tokens, function(y){


### PR DESCRIPTION
This PR fixes #331 . Previously, basic searches would fail at the summarization stage when filtering stopwords in n-gram title candidates that contain invalid regexes (e.g. `(candidate)`).
The fix replaces grepl with a stringi-function that is more robust to edge cases.

The PR has been tested with searches on the full pipeline on BASE and PubMed for `brown, fbi, red` that previously failed, and a range of other searches that indicated no deterioration.