### PR TITLE
Linkedcat streamgraph backend

### DIFF
--- a/doc/server_config.md
+++ b/doc/server_config.md
@@ -45,6 +45,7 @@ Make sure you have the following packages installed:
   * onehot (for feature engineering)
   * textcat (for language recognition)
   * solrium (for interfacing with SOLR servers, install with `devtools::install_github("chreman/solrium")`)
+  * tidyr
 
 * phantomjs 2.1+ (http://phantomjs.org/), if you want to use the snapshot feature
 

--- a/server/classes/headstart/preprocessing/calculation/RCalculation.php
+++ b/server/classes/headstart/preprocessing/calculation/RCalculation.php
@@ -56,17 +56,16 @@ class RCalculation extends Calculation {
         $binary = $ini["binary"];
         $script = $base_dir . "other-scripts/streamgraph.R";
 
-        $tmp_json = tmpfile();
-        $tmp_meta = stream_get_meta_data($tmp_json);
+        $tmp_jsonfile = tmpfile();
+        $tmp_meta = stream_get_meta_data($tmp_jsonfile);
         $tmp_jsonname = $tmp_meta["uri"];
-        fwrite($tmp_json, $output_json);
+        fwrite($tmp_jsonfile, $output_json);
 
         $path = '"' . $binary . '" '
                 . $script
                 . ' "' . $working_dir . '" '
-                . '"' . $service . '"'
+                . '"' . $service . '" '
                 . '"' . $tmp_jsonname . '"';
-
         exec($path, $streamgraph_json);
 
         return $streamgraph_json;

--- a/server/classes/headstart/preprocessing/calculation/RCalculation.php
+++ b/server/classes/headstart/preprocessing/calculation/RCalculation.php
@@ -49,7 +49,7 @@ class RCalculation extends Calculation {
         return $output_r;
     }
 
-    public function performStreamgraphCalculation($output_json) {
+    public function performStreamgraphCalculation($service, $output_json) {
         $ini = $this->ini_array["calculation"];
 
         $base_dir = $this->ini_array["general"]["preprocessing_dir"];
@@ -65,6 +65,7 @@ class RCalculation extends Calculation {
         $path = '"' . $binary . '" '
                 . $script
                 . ' "' . $working_dir . '" '
+                . '"' . $service . '"'
                 . '"' . $tmp_jsonname . '"';
 
         exec($path, $streamgraph_json);

--- a/server/classes/headstart/preprocessing/calculation/RCalculation.php
+++ b/server/classes/headstart/preprocessing/calculation/RCalculation.php
@@ -13,39 +13,62 @@ use headstart\library;
 require_once 'Calculation.php';
 
 class RCalculation extends Calculation {
-      
+
     public function performCalculationAndWriteOutputToFile($working_dir) {
         $ini = $this->ini_array["calculation"];
         $output = $this->ini_array["output"];
-        
+
         $base_dir = $this->ini_array["general"]["preprocessing_dir"];
         $binary = $ini["binary"];
         $script = $base_dir . $ini["script"];
-        
+
         $path = '"' . $binary . '" ' .$script. ' "' . $working_dir . '" "'
                 . $output["cooc"] . '" "' . $output["metadata"] . '" "' . $output["output_scaling_clustering"] . '" "' . $ini["mode"] .'"';
-        
+
         library\Toolkit::info($path);
-        exec($path); 
+        exec($path);
     }
-    
+
     public function performCalculationAndReturnOutputAsJSON($working_dir, $query, $params, $service) {
         $ini = $this->ini_array["calculation"];
-        
+
         $base_dir = $this->ini_array["general"]["preprocessing_dir"];
         $binary = $ini["binary"];
         $script = $base_dir . $ini["script"];
-        
+
         $path = '"' . $binary . '" ' .$script. ' "' . $working_dir . '" "' . $query . '" "'
                 . $service . '"';
-        
+
         if($params != null) {
             $path .= ' "' . $params . '"';
         }
-        
+
         //library\Toolkit::info($path);
         exec($path, $output_r);
-        
+
         return $output_r;
+    }
+
+    public function performStreamgraphCalculation($output_json) {
+        $ini = $this->ini_array["calculation"];
+
+        $base_dir = $this->ini_array["general"]["preprocessing_dir"];
+        $working_dir = $this->$ini_array["general"]["preprocessing_dir"] . $this->$ini_array["output"]["output_dir"];
+        $binary = $ini["binary"];
+        $script = $base_dir . "other-scripts/streamgraph.R";
+
+        $tmp_json = tmpfile();
+        $tmp_meta = stream_get_meta_data($tmp_json);
+        $tmp_jsonname = $tmp_meta["uri"];
+        fwrite($tmp_json, $output_json);
+
+        $path = '"' . $binary . '" '
+                . $script
+                . ' "' . $working_dir . '" '
+                . '"' . $tmp_jsonname . '"';
+
+        exec($path, $streamgraph_json);
+
+        return $streamgraph_json;
     }
 }

--- a/server/classes/headstart/preprocessing/calculation/RCalculation.php
+++ b/server/classes/headstart/preprocessing/calculation/RCalculation.php
@@ -49,11 +49,10 @@ class RCalculation extends Calculation {
         return $output_r;
     }
 
-    public function performStreamgraphCalculation($service, $output_json) {
+    public function performStreamgraphCalculation($working_dir, $service, $output_json) {
         $ini = $this->ini_array["calculation"];
 
         $base_dir = $this->ini_array["general"]["preprocessing_dir"];
-        $working_dir = $this->$ini_array["general"]["preprocessing_dir"] . $this->$ini_array["output"]["output_dir"];
         $binary = $ini["binary"];
         $script = $base_dir . "other-scripts/streamgraph.R";
 

--- a/server/preprocessing/other-scripts/linkedcat_authorview.R
+++ b/server/preprocessing/other-scripts/linkedcat_authorview.R
@@ -53,32 +53,33 @@ get_papers <- function(query, params, limit=100) {
   }
 
   # make results dataframe
-  metadata <- data.frame(res$search)
+  search_res = res$search
+  metadata <- data.frame(search_res$id)
+  names(metadata) <- c('id')
 
-  metadata[is.na(metadata)] <- ""
-  metadata$subject <- if (!is.null(metadata$keyword_a)) unlist(lapply(metadata$keyword_a, function(x) {gsub("; $", "", x)})) else ""
+  metadata$subject <- if (!is.null(search_res$keyword_a)) unlist(lapply(search_res$keyword_a, function(x) {gsub("; $", "", x)})) else ""
   metadata$subject <- unlist(lapply(metadata$subject, function(x) {gsub("; ; ", "; ", x)}))
-  metadata$authors <- paste(metadata$author100_a, metadata$author700_a, sep="; ")
+  metadata$authors <- paste(search_res$author100_a, search_res$author700_a, sep="; ")
   metadata$authors <- unlist(lapply(metadata$authors, function(x) {gsub("; $|,$", "", x)}))
   metadata$authors <- unlist(lapply(metadata$authors, function(x) {gsub("^; ", "", x)}))
   metadata$author_date <- metadata$author100_d
-  metadata$title <- if (!is.null(metadata$main_title)) metadata$main_title else ""
-  metadata$paper_abstract <- if (!is.null(metadata$ocrtext)) metadata$ocrtext else ""
-  metadata$year <- metadata$pub_year
+  metadata$title <- if (!is.null(search_res$main_title)) search_res$main_title else ""
+  metadata$paper_abstract <- if (!is.null(search_res$ocrtext)) unlist(lapply(search_res$ocrtext, substr, start=0, stop=1000)) else ""
+  metadata$year <- search_res$pub_year
   metadata$readers <- 0
-  metadata$url <- metadata$id
+  metadata$url <- search_res$id
   metadata$link <- "" # needs fix
-  metadata$published_in <- metadata$host_label
+  metadata$published_in <- search_res$host_label
   metadata$oa_state <- 1
   metadata$subject_orig = metadata$subject
   metadata$relevance = c(nrow(metadata):1)
-  metadata$bkl_caption = if (!is.null(metadata$bkl_caption)) metadata$bkl_caption else ""
-  metadata$bkl_top_caption = if (!is.null(metadata$bkl_top_caption)) metadata$bkl_top_caption else ""
+  metadata$bkl_caption = if (!is.null(search_res$bkl_caption)) search_res$bkl_caption else ""
+  metadata$bkl_top_caption = if (!is.null(search_res$bkl_top_caption)) search_res$bkl_top_caption else ""
 
   text = data.frame(matrix(nrow=nrow(metadata)))
   text$id = metadata$id
   # Add all keywords, including classification to text
-  text$content = paste(metadata$main_title, metadata$keyword_a,
+  text$content = paste(search_res$main_title, search_res$keyword_a,
                        sep = " ")
 
 
@@ -104,7 +105,7 @@ build_query <- function(query, params, limit){
                 'author700_a', 'author700_d', 'author700_0',
                 'bkl_caption', 'bkl_top_caption',
                 'keyword_a', 'tags', 'category', 'bib', 'language_code',
-                'ocrtext_good', 'ocrtext')
+                'ocrtext')
   q <- paste(paste0(q_fields, ':', '"', params$author_id, '"'), collapse = " ")
   q_params <- list(q = q, rows = limit, fl = r_fields)
   return(q_params)

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -67,14 +67,23 @@ if (service == 'linkedcat' || service == 'linkedcat_authorview') {
                       %>% complete(boundary_label, stream_item, fill=list(count=0))
                       %>% group_by(boundary_label, stream_item, .drop=FALSE) 
                       %>% summarise(count=sum(count), ids=paste(id, collapse=", ")))
-  #sg_data$area <- metadata %>% group_by(boundary_label, area) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
+  sg_data$area <- (metadata
+                   %>% rename(stream_item=area) 
+                   %>% mutate(count=1) 
+                   %>% complete(boundary_label, stream_item, fill=list(count=0))
+                   %>% group_by(boundary_label, stream_item, .drop=FALSE) 
+                   %>% summarise(count=sum(count), ids=paste(id, collapse=", ")))
   #sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(boundary_label, bkl_caption) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
+  output <- list()
+  output$x <- sg_data$x
+  output$subject <- post_process(sg_data$subject)
+  output$area <- post_process(sg_data$area)
 }
+
+
 
 end.time <- Sys.time()
 time.taken <- end.time - start.time
 sglog$info(paste("Time taken streamgraph:", time.taken, sep=" "))
-output <- list()
-output$subject <- post_process(sg_data$subject)
-output$x <- sg_data$x
+
 print(toJSON(output))

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -75,7 +75,9 @@ if (service == 'linkedcat' || service == 'linkedcat_authorview') {
             %>% head(20)
             %>% select(stream_item) 
             %>% pull())
-  sg_data$subject <- sg_data$subject %>% subset(stream_item %in% top_20)
+  sg_data$subject <- (sg_data$subject
+                      %>% subset(stream_item %in% top_20)
+                      %>% arrange(match(stream_item, top_20), boundary_label))
   sg_data$area <- (metadata
                    %>% rename(stream_item=area) 
                    %>% mutate(count=1) 

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -2,6 +2,7 @@ rm(list = ls())
 library(logging)
 library(jsonlite)
 library(dplyr)
+library(data.table)
 library(tidyr)
 
 args <- commandArgs(TRUE)
@@ -28,9 +29,9 @@ metadata <- fromJSON(tmp_json)
 sg_data = list()
 
 if (service == 'linkedcat' || service == 'linkedcat_authorview') {
-  sg_data$area <- metadata %>% group_by(year, area) %>% count
-  sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% group_by(year, subject) %>% count
-  sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(year, bkl_caption) %>% count
+  sg_data$area <- metadata %>% group_by(year, area) %>% summarize(count = uniqueN(id), ids = paste(id, collapse=", "))
+  sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% group_by(year, subject) %>% summarize(count = uniqueN(id), ids = paste(id, collapse=", "))
+  sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(year, bkl_caption) %>% summarize(count = uniqueN(id), ids = paste(id, collapse=", "))
 }
 
 end.time <- Sys.time()

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -1,20 +1,30 @@
 rm(list = ls())
+library(logging)
 library(jsonlite)
 library(dplyr)
 library(tidyr)
 
 args <- commandArgs(TRUE)
 wd <- args[1]
-tmp_json <- args[2]
+service <- args[2]
+tmp_json <- args[3]
 
 setwd(wd) #Don't forget to set your working directory
 
+sglog <- getLogger('sg')
+
+start.time <- Sys.time()
 metadata <- fromJSON(tmp_json)
 
 sg_data = list()
 
-sg_data$area <- metadata %>% group_by(year, area) %>% count
-sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% group_by(year, subject) %>% count
-sg_data$classification <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(year, bkl_caption) %>% count
+if (service == 'linkedcat_authorview') {
+  sg_data$area <- metadata %>% group_by(year, area) %>% count
+  sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% group_by(year, subject) %>% count
+  sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(year, bkl_caption) %>% count
+}
 
+end.time <- Sys.time()
+time.taken <- end.time - start.time
+sglog$info(paste("Time taken - streamgraph:", time.taken, sep=" "))
 print(toJSON(sg_data))

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -18,7 +18,7 @@ metadata <- fromJSON(tmp_json)
 
 sg_data = list()
 
-if (service == 'linkedcat_authorview') {
+if (service == 'linkedcat') {
   sg_data$area <- metadata %>% group_by(year, area) %>% count
   sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% group_by(year, subject) %>% count
   sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(year, bkl_caption) %>% count
@@ -26,5 +26,5 @@ if (service == 'linkedcat_authorview') {
 
 end.time <- Sys.time()
 time.taken <- end.time - start.time
-sglog$info(paste("Time taken - streamgraph:", time.taken, sep=" "))
+sglog$info(paste("Time taken streamgraph:", time.taken, sep=" "))
 print(toJSON(sg_data))

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -36,7 +36,7 @@ if (service == 'linkedcat' || service == 'linkedcat_authorview') {
   boundaries <- boundaries %>% separate_rows(year, sep=", ")
   metadata <- merge(x = metadata, y = boundaries, by.x='year', by.y='year')
   sg_data$area <- metadata %>% group_by(boundary_label, area) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
-  sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% group_by(boundary_label, subject) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
+  metadata %>% separate_rows(subject, sep="; ") %>% mutate(count=1) %>% complete(boundary_label, subject, fill=list(count=0)) %>% group_by(boundary_label, subject, .drop=FALSE) %>% summarize(count=sum(count), ids=list(unique(id)))
   sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(boundary_label, bkl_caption) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
 }
 

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -41,10 +41,11 @@ post_process <- function(sg_data) {
                               %>% filter(ids != "NA")
                               %>% select(ids) 
                               %>% pull())
-    new_item$ids_timestep <- tmp$ids
+    new_item$ids_timestep <- lapply(tmp$ids, function(x) unlist(strsplit(x, split=", ")))
     df <- rbind(df, rbind(new_item))
   }
   rownames(df) <- 1:nrow(df)
+  df$name <- unlist(df$name)
   return(df)
 }
 
@@ -73,5 +74,5 @@ end.time <- Sys.time()
 time.taken <- end.time - start.time
 sglog$info(paste("Time taken streamgraph:", time.taken, sep=" "))
 output <- list()
-output$subject <- post_process(sg_data$subject)
-print(toJSON(output, auto_unbox = TRUE))
+output$subject <- post_process(sg_data)
+print(toJSON(output))

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -33,7 +33,7 @@ post_process <- function(sg_data) {
     new_item <- list()
     new_item$name <- item
     tmp <- sg_data %>% subset(stream_item == item)
-    new_item$data <- tmp$count
+    new_item$y <- tmp$count
     new_item$ids_overall <- (tmp
                               %>% ungroup()
                               %>% separate_rows(ids, sep=", ")
@@ -57,6 +57,7 @@ if (service == 'linkedcat' || service == 'linkedcat_authorview') {
                            max=c(1849, 1859, 1869, 1879, 1889, 1899, 1909, 1918))
   boundaries$year <- apply(boundaries, 1, function(x) {paste(x[1]:x[2], collapse=", ")})
   boundaries$boundary_label <- apply(boundaries, 1, function(x) {paste(x[1], x[2], sep=" - ")})
+  sg_data$x <- boundaries$boundary_label
   boundaries <- boundaries %>% separate_rows(year, sep=", ") %>% select(year, boundary_label)
   metadata <- merge(x = metadata, y = boundaries, by.x='year', by.y='year', all = TRUE)
   sg_data$subject <- (metadata 
@@ -75,4 +76,5 @@ time.taken <- end.time - start.time
 sglog$info(paste("Time taken streamgraph:", time.taken, sep=" "))
 output <- list()
 output$subject <- post_process(sg_data$subject)
+output$x <- sg_data$x
 print(toJSON(output))

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -29,9 +29,9 @@ metadata <- fromJSON(tmp_json)
 sg_data = list()
 
 if (service == 'linkedcat' || service == 'linkedcat_authorview') {
-  sg_data$area <- metadata %>% group_by(year, area) %>% summarize(count = uniqueN(id), ids = paste(id, collapse=", "))
-  sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% group_by(year, subject) %>% summarize(count = uniqueN(id), ids = paste(id, collapse=", "))
-  sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(year, bkl_caption) %>% summarize(count = uniqueN(id), ids = paste(id, collapse=", "))
+  sg_data$area <- metadata %>% group_by(year, area) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
+  sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% group_by(year, subject) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
+  sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(year, bkl_caption) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
 }
 
 end.time <- Sys.time()

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -73,4 +73,4 @@ time.taken <- end.time - start.time
 sglog$info(paste("Time taken streamgraph:", time.taken, sep=" "))
 output <- list()
 output$subject <- post_process(sg_data$subject)
-print(toJSON(output))
+print(toJSON(output, auto_unbox = TRUE))

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -11,6 +11,15 @@ tmp_json <- args[3]
 
 setwd(wd) #Don't forget to set your working directory
 
+source('../other-scripts/utils.R')
+DEBUG = FALSE
+
+if (DEBUG==TRUE){
+  setup_logging('DEBUG')
+} else {
+  setup_logging('INFO')
+}
+
 sglog <- getLogger('sg')
 
 start.time <- Sys.time()

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -31,12 +31,12 @@ sg_data = list()
 if (service == 'linkedcat' || service == 'linkedcat_authorview') {
   boundaries <- data.frame(min=c(1847, 1850, 1860, 1870, 1880, 1890, 1900, 1910),
                            max=c(1849, 1859, 1869, 1879, 1889, 1899, 1909, 1918))
-  boundaries$year <- lapply(boundaries, function(x) {paste(x[1]:x[2], collapse=", ")})
+  boundaries$year <- apply(boundaries, 1, function(x) {paste(x[1]:x[2], collapse=", ")})
   boundaries$boundary_label <- apply(boundaries, 1, function(x) {paste(x[1], x[2], sep=" - ")})
-  boundaries <- boundaries %>% separate_rows(year, sep=", ")
-  metadata <- merge(x = metadata, y = boundaries, by.x='year', by.y='year')
+  boundaries <- boundaries %>% separate_rows(year, sep=", ") %>% select(year, boundary_label)
+  metadata <- merge(x = metadata, y = boundaries, by.x='year', by.y='year', all = TRUE)
   sg_data$area <- metadata %>% group_by(boundary_label, area) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
-  metadata %>% separate_rows(subject, sep="; ") %>% mutate(count=1) %>% complete(boundary_label, subject, fill=list(count=0)) %>% group_by(boundary_label, subject, .drop=FALSE) %>% summarize(count=sum(count), ids=list(unique(id)))
+  sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% mutate(count=1) %>% complete(boundary_label, subject, fill=list(count=0)) %>% group_by(boundary_label, subject, .drop=FALSE) %>% summarise(count=sum(count), ids=paste(id, collapse=", "))
   sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(boundary_label, bkl_caption) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
 }
 

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -67,6 +67,15 @@ if (service == 'linkedcat' || service == 'linkedcat_authorview') {
                       %>% complete(boundary_label, stream_item, fill=list(count=0))
                       %>% group_by(boundary_label, stream_item, .drop=FALSE) 
                       %>% summarise(count=sum(count), ids=paste(id, collapse=", ")))
+  top_20 <-(sg_data$subject
+            %>% group_by(stream_item) 
+            %>% summarise(sum = sum(count))
+            %>% arrange(desc(sum))
+            %>% drop_na()
+            %>% head(20)
+            %>% select(stream_item) 
+            %>% pull())
+  sg_data$subject <- sg_data$subject %>% subset(stream_item %in% top_20)
   sg_data$area <- (metadata
                    %>% rename(stream_item=area) 
                    %>% mutate(count=1) 

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -1,0 +1,20 @@
+rm(list = ls())
+library(jsonlite)
+library(dplyr)
+library(tidyr)
+
+args <- commandArgs(TRUE)
+wd <- args[1]
+tmp_json <- args[2]
+
+setwd(wd) #Don't forget to set your working directory
+
+metadata <- fromJSON(tmp_json)
+
+sg_data = list()
+
+sg_data$area <- metadata %>% group_by(year, area) %>% count
+sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% group_by(year, subject) %>% count
+sg_data$classification <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(year, bkl_caption) %>% count
+
+print(toJSON(sg_data))

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -28,23 +28,24 @@ metadata <- fromJSON(tmp_json)
 
 
 post_process <- function(sg_data) {
-  data_json <- list()
+  df <- data.frame(row.names = c('name', 'data', 'ids_overall', 'ids_timestep'))
   for (item in unique(sg_data[!is.na(sg_data$stream_item),]$stream_item)) {
-    item_json <- list()
-    item_json$name <- item
+    new_item <- list()
+    new_item$name <- item
     tmp <- sg_data %>% subset(stream_item == item)
-    item_json$data <- tmp$count
-    item_json$ids_overall <- (tmp
+    new_item$data <- tmp$count
+    new_item$ids_overall <- (tmp
                               %>% ungroup()
                               %>% separate_rows(ids, sep=", ")
                               %>% distinct(ids) 
                               %>% filter(ids != "NA")
                               %>% select(ids) 
                               %>% pull())
-    item_json$ids_timestep <- tmp$ids
-    data_json[[item]] <- item_json
+    new_item$ids_timestep <- tmp$ids
+    df <- rbind(df, rbind(new_item))
   }
-  return(data_json)
+  rownames(df) <- 1:nrow(df)
+  return(df)
 }
 
 

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -37,4 +37,4 @@ if (service == 'linkedcat' || service == 'linkedcat_authorview') {
 end.time <- Sys.time()
 time.taken <- end.time - start.time
 sglog$info(paste("Time taken streamgraph:", time.taken, sep=" "))
-print(toJSON(sg_data))
+print(toJSON(sg_data, auto_unbox = TRUE))

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -35,9 +35,15 @@ if (service == 'linkedcat' || service == 'linkedcat_authorview') {
   boundaries$boundary_label <- apply(boundaries, 1, function(x) {paste(x[1], x[2], sep=" - ")})
   boundaries <- boundaries %>% separate_rows(year, sep=", ") %>% select(year, boundary_label)
   metadata <- merge(x = metadata, y = boundaries, by.x='year', by.y='year', all = TRUE)
-  sg_data$area <- metadata %>% group_by(boundary_label, area) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
-  sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% mutate(count=1) %>% complete(boundary_label, subject, fill=list(count=0)) %>% group_by(boundary_label, subject, .drop=FALSE) %>% summarise(count=sum(count), ids=paste(id, collapse=", "))
-  sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(boundary_label, bkl_caption) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
+  sg_data$subject <- (metadata 
+                      %>% separate_rows(subject, sep="; ") 
+                      %>% rename(stream_item=subject) 
+                      %>% mutate(count=1) 
+                      %>% complete(boundary_label, stream_item, fill=list(count=0))
+                      %>% group_by(boundary_label, stream_item, .drop=FALSE) 
+                      %>% summarise(count=sum(count), ids=paste(id, collapse=", ")))
+  #sg_data$area <- metadata %>% group_by(boundary_label, area) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
+  #sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(boundary_label, bkl_caption) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
 }
 
 end.time <- Sys.time()

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -74,5 +74,5 @@ end.time <- Sys.time()
 time.taken <- end.time - start.time
 sglog$info(paste("Time taken streamgraph:", time.taken, sep=" "))
 output <- list()
-output$subject <- post_process(sg_data)
+output$subject <- post_process(sg_data$subject)
 print(toJSON(output))

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -29,9 +29,15 @@ metadata <- fromJSON(tmp_json)
 sg_data = list()
 
 if (service == 'linkedcat' || service == 'linkedcat_authorview') {
-  sg_data$area <- metadata %>% group_by(year, area) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
-  sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% group_by(year, subject) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
-  sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(year, bkl_caption) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
+  boundaries <- data.frame(min=c(1847, 1850, 1860, 1870, 1880, 1890, 1900, 1910),
+                           max=c(1849, 1859, 1869, 1879, 1889, 1899, 1909, 1918))
+  boundaries$year <- lapply(boundaries, function(x) {paste(x[1]:x[2], collapse=", ")})
+  boundaries$boundary_label <- apply(boundaries, 1, function(x) {paste(x[1], x[2], sep=" - ")})
+  boundaries <- boundaries %>% separate_rows(year, sep=", ")
+  metadata <- merge(x = metadata, y = boundaries, by.x='year', by.y='year')
+  sg_data$area <- metadata %>% group_by(boundary_label, area) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
+  sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% group_by(boundary_label, subject) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
+  sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(boundary_label, bkl_caption) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
 }
 
 end.time <- Sys.time()

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -18,7 +18,7 @@ metadata <- fromJSON(tmp_json)
 
 sg_data = list()
 
-if (service == 'linkedcat') {
+if (service == 'linkedcat' || service == 'linkedcat_authorview') {
   sg_data$area <- metadata %>% group_by(year, area) %>% count
   sg_data$subject <- metadata %>% separate_rows(subject, sep="; ") %>% group_by(year, subject) %>% count
   sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(year, bkl_caption) %>% count

--- a/server/services/getLatestRevision.php
+++ b/server/services/getLatestRevision.php
@@ -32,6 +32,11 @@ if ($context === true) {
      $sg_output = $calculation->performStreamgraphCalculation($working_dir, $return_data["context"]["service"], $return_data["data"]);
      $sg_output_json = end($sg_output);
      $sg_output_json = mb_convert_encoding($sg_output_json, "UTF-8");
+
+     if (!library\Toolkit::isJSON($sg_output_json) || $sg_output_json == "null" || $sg_output_json == null) {
+
+         $sg_output_json = json_encode(array("status" => "error"));
+     }
      $return_data["streamgraph"] = $sg_output_json;
    }
    $jsonData = json_encode($return_data);

--- a/server/services/getLatestRevision.php
+++ b/server/services/getLatestRevision.php
@@ -31,7 +31,7 @@ if ($context === true) {
      $working_dir = $ini_array["general"]["preprocessing_dir"] . $ini_array["output"]["output_dir"];
      $sg_output = $calculation->performStreamgraphCalculation($working_dir, $return_data["context"]["service"], $return_data["data"]);
      $sg_output_json = end($sg_output);
-     $sg_output_json = mb_convert_encoding($sg_output_json);
+     $sg_output_json = mb_convert_encoding($sg_output_json, "UTF-8");
      $return_data["streamgraph"] = $sg_output_json;
    }
    $jsonData = json_encode($return_data);

--- a/server/services/getLatestRevision.php
+++ b/server/services/getLatestRevision.php
@@ -2,6 +2,7 @@
 
 header('Content-type: application/json');
 
+require dirname(__FILE__) . '/../classes/headstart/preprocessing/calculation/RCalculation.php';
 require dirname(__FILE__) . '/../classes/headstart/persistence/SQLitePersistence.php';
 require_once dirname(__FILE__) . '/../classes/headstart/library/CommUtils.php';
 require_once dirname(__FILE__) . '/../classes/headstart/library/toolkit.php';
@@ -15,17 +16,23 @@ $ini_array = library\Toolkit::loadIni($INI_DIR);
 $vis_id = library\CommUtils::getParameter($_GET, "vis_id");
 $context = filter_input(INPUT_GET, "context", FILTER_VALIDATE_BOOLEAN,
     array("flags" => FILTER_NULL_ON_FAILURE));
+$streamgraph = filter_input(INPUT_GET, "streamgraph", FILTER_VALIDATE_BOOLEAN,
+    array("flags" => FILTER_NULL_ON_FAILURE));
 
 $persistence = new headstart\persistence\SQLitePersistence($ini_array["connection"]["sqlite_db"]);
 
 if ($context === true) {
    $data = $persistence->getLastVersion($vis_id, $details = false, $context = true)[0];
    $return_data = array("context" => array("id" => $data["rev_vis"], "query" => $data["vis_query"], "service" => $data["vis_title"]
-                            , "timestamp" => $data["rev_timestamp"], "params" => $data["vis_params"]), 
+                            , "timestamp" => $data["rev_timestamp"], "params" => $data["vis_params"]),
                         "data" => $data["rev_data"]);
+   if ($streamgraph === true) {
+     $calculation = new \headstart\preprocessing\calculation\RCalculation($ini_array);
+     $return_data["streamgraph"] = $calculation->performStreamgraphCalculation(json_encode($return_data["data"]));
+   }
    $jsonData = json_encode($return_data);
    library\CommUtils::echoOrCallback($jsonData, $_GET);
 } else {
     $jsonData = $persistence->getLastVersion($vis_id);
-    library\CommUtils::echoOrCallback($jsonData[0], $_GET);    
+    library\CommUtils::echoOrCallback($jsonData[0], $_GET);
 }

--- a/server/services/getLatestRevision.php
+++ b/server/services/getLatestRevision.php
@@ -30,7 +30,7 @@ if ($context === true) {
    if ($streamgraph === true) {
      $calculation = new headstart\preprocessing\calculation\RCalculation($ini_array);
      $working_dir = $ini_array["general"]["preprocessing_dir"] . $ini_array["output"]["output_dir"];
-     $return_data["streamgraph"] = $calculation->performStreamgraphCalculation($working_dir, $return_data["context"]["service"], $return_data["data"]);
+     $return_data["streamgraph"] = $calculation->performStreamgraphCalculation($working_dir, $return_data["context"]["service"], $return_data["data"])[0];
    }
    $jsonData = json_encode($return_data);
    library\CommUtils::echoOrCallback($jsonData, $_GET);

--- a/server/services/getLatestRevision.php
+++ b/server/services/getLatestRevision.php
@@ -26,7 +26,6 @@ if ($context === true) {
    $return_data = array("context" => array("id" => $data["rev_vis"], "query" => $data["vis_query"], "service" => $data["vis_title"]
                             , "timestamp" => $data["rev_timestamp"], "params" => $data["vis_params"]),
                         "data" => $data["rev_data"]);
-   $streamgraph = true;
    if ($streamgraph === true) {
      $calculation = new headstart\preprocessing\calculation\RCalculation($ini_array);
      $working_dir = $ini_array["general"]["preprocessing_dir"] . $ini_array["output"]["output_dir"];

--- a/server/services/getLatestRevision.php
+++ b/server/services/getLatestRevision.php
@@ -28,7 +28,7 @@ if ($context === true) {
                         "data" => $data["rev_data"]);
    if ($streamgraph === true) {
      $calculation = new \headstart\preprocessing\calculation\RCalculation($ini_array);
-     $return_data["streamgraph"] = $calculation->performStreamgraphCalculation(json_encode($return_data["data"]));
+     $return_data["streamgraph"] = $calculation->performStreamgraphCalculation($return_data["context"]["service"], json_encode($return_data["data"]));
    }
    $jsonData = json_encode($return_data);
    library\CommUtils::echoOrCallback($jsonData, $_GET);

--- a/server/services/getLatestRevision.php
+++ b/server/services/getLatestRevision.php
@@ -29,7 +29,10 @@ if ($context === true) {
    if ($streamgraph === true) {
      $calculation = new headstart\preprocessing\calculation\RCalculation($ini_array);
      $working_dir = $ini_array["general"]["preprocessing_dir"] . $ini_array["output"]["output_dir"];
-     $return_data["streamgraph"] = $calculation->performStreamgraphCalculation($working_dir, $return_data["context"]["service"], $return_data["data"])[0];
+     $sg_output = $calculation->performStreamgraphCalculation($working_dir, $return_data["context"]["service"], $return_data["data"]);
+     $sg_output_json = end($sg_output);
+     $sg_output_json = mb_convert_encoding($sg_output_json);
+     $return_data["streamgraph"] = $sg_output_json;
    }
    $jsonData = json_encode($return_data);
    library\CommUtils::echoOrCallback($jsonData, $_GET);

--- a/server/services/getLatestRevision.php
+++ b/server/services/getLatestRevision.php
@@ -26,9 +26,11 @@ if ($context === true) {
    $return_data = array("context" => array("id" => $data["rev_vis"], "query" => $data["vis_query"], "service" => $data["vis_title"]
                             , "timestamp" => $data["rev_timestamp"], "params" => $data["vis_params"]),
                         "data" => $data["rev_data"]);
+   $streamgraph = true;
    if ($streamgraph === true) {
-     $calculation = new \headstart\preprocessing\calculation\RCalculation($ini_array);
-     $return_data["streamgraph"] = $calculation->performStreamgraphCalculation($return_data["context"]["service"], json_encode($return_data["data"]));
+     $calculation = new headstart\preprocessing\calculation\RCalculation($ini_array);
+     $working_dir = $ini_array["general"]["preprocessing_dir"] . $ini_array["output"]["output_dir"];
+     $return_data["streamgraph"] = $calculation->performStreamgraphCalculation($working_dir, $return_data["context"]["service"], $return_data["data"]);
    }
    $jsonData = json_encode($return_data);
    library\CommUtils::echoOrCallback($jsonData, $_GET);


### PR DESCRIPTION
This PR introduces streamgraph-calculation into the backend.

The calculation is called at the getLatestRevision-stage when the frontend loads a map-representation.
The appropriate function in the frontend needs to set an additional parameter `streamgraph` to true or false, similar how the `context` parameter is set.
If the parameter is true, the JSON-maprepresentation is handed to a new function `performStreamgraphCalculation` in RCalculation.php, which works similar to the existing API routes.
Here a new R-service `streamgraph.R` is called, which creates streamgraph data accordingly to the service - only LinkedCat is currently implemented.
The streamgraph data is then added to the return json which then has following key-value pairs:

```json
{"context": {"k": "v"},
 "data": ["list of documents as key-values"],
 "streamgraph": {"streamgraph-field 1": ["data list of key-values"],
                 "streamgraph-field 2": ["data list of key-values"]
                 }
}
```

As an example, for LinkedCat the streamgraph-value will look as following for the two metadata-fields of area and bkl_caption:

```
{
  "area": [
    {
      "year": 1849,
      "area": "Geschichte, Österreich",
      "count": 1,
      "ids": "AC15205265"
    },
    {
      "year": 1850,
      "area": "Geschichte, Österreich",
      "count": 1,
      "ids": "AC15206478"
    },
    {
      "year": 1852,
      "area": "Geschichte, Österreich",
      "count": 1,
      "ids": "AC15038470"
    },
    {
      "year": 1852,
      "area": "IbnḪaldūn",
      "count": 1,
      "ids": "AC15038409"
    },
    {
      "year": 1852,
      "area": "Taman und Asow, Bessarabien die Krim, Habsburgische Excurse III",
      "count": 1,
      "ids": "AC15037344"
    },
    {
      "year": 1853,
      "area": "Ethnologie, Litauen, Litauisch",
      "count": 1,
      "ids": "AC15041924"
    }
  },
  "bkl_caption":
    {
      "year": 1887,
      "bkl_caption": "Deutsche Sprache",
      "count": 1,
      "ids": "AC15193500"
    },
    {
      "year": 1887,
      "bkl_caption": "Hamito-semitische Sprachen und Literaturen: Allgemeines",
      "count": 2,
      "ids": [
        "AC15193038",
        "AC15193500"
      ]
    },
    {
      "year": 1887,
      "bkl_caption": "Rechtsgeschichte",
      "count": 1,
      "ids": "AC15193177"
    },
    {
      "year": 1887,
      "bkl_caption": "Sprachwissenschaft: Allgemeines",
      "count": 1,
      "ids": "AC15193500"
    },
    {
      "year": 1888,
      "bkl_caption": "Hamito-semitische Sprachen und Literaturen: Allgemeines",
      "count": 1,
      "ids": "AC15194545"
    }
  ]
}
```
Currently three streamgraph-data sets are calculated: one aggregating area-titles, one aggregating subjects (split into singular ones), and one aggregating basisklassifikationen (split into singular ones).


Notes:
* It requires `tidyr` as an additional package.
* It adds approximately 500ms to loading time.

This approach has been tested (with a hardcoded streamgraph=true in getLatestRevision) until the stage where the enriched JSON can be inspected in the interface as a reponse of the GET-request.