### PR TITLE
added 'based' to stopwords

### DIFF
--- a/server/preprocessing/resources/english.stop
+++ b/server/preprocessing/resources/english.stop
@@ -56,6 +56,7 @@ available
 away
 awfully
 b
+based
 be
 became
 because


### PR DESCRIPTION
This PR fixes #266 by adding "based" to the stopwords-list.

Improvements can be seen by searching for "based" in both PubMed and BASE.