### PR TITLE
Linkedcat titleonly

### DIFF
--- a/server/preprocessing/other-scripts/summarize.R
+++ b/server/preprocessing/other-scripts/summarize.R
@@ -122,8 +122,8 @@ get_cluster_corpus <- function(clusters, metadata, api, stops, taxonomy_separato
       all_subjects = paste(subjects, collapse=" ")
     } else {
       all_subjects = paste(subjects, title_ngrams$bigrams, title_ngrams$trigrams, collapse=" ")
+      all_subjects = gsub(",", ";", all_subjects)
     }
-    all_subjects = gsub(",", ";", all_subjects)
     subjectlist = c(subjectlist, all_subjects)
   }
   nn_corpus <- Corpus(VectorSource(subjectlist))

--- a/server/preprocessing/other-scripts/summarize.R
+++ b/server/preprocessing/other-scripts/summarize.R
@@ -37,11 +37,12 @@ prune_ngrams <- function(ngrams, stops){
   return (tokens)
 }
 
-create_cluster_labels <- function(clusters, metadata, lang,
+create_cluster_labels <- function(clusters, metadata,
+                                  api, lang,
                                   unlowered_corpus,
                                   weightingspec,
                                   top_n, stops, taxonomy_separator="/") {
-  nn_corpus <- get_cluster_corpus(clusters, metadata, stops, taxonomy_separator)
+  nn_corpus <- get_cluster_corpus(clusters, metadata, api, stops, taxonomy_separator)
   nn_tfidf <- TermDocumentMatrix(nn_corpus, control = list(
                                       tokenize = SplitTokenizer,
                                       weighting = function(x) weightSMART(x, spec="ntn"),
@@ -88,7 +89,7 @@ match_keyword_case <- function(x, type_counts) {
 }
 
 
-get_cluster_corpus <- function(clusters, metadata, stops, taxonomy_separator) {
+get_cluster_corpus <- function(clusters, metadata, api, stops, taxonomy_separator) {
   subjectlist = list()
   for (k in seq(1, clusters$num_clusters)) {
     group = c(names(clusters$groups[clusters$groups == k]))
@@ -115,7 +116,11 @@ get_cluster_corpus <- function(clusters, metadata, stops, taxonomy_separator) {
       subjects = lapply(subjects, function(x){paste(unlist(x), collapse=";")})
       subjects = mapply(paste, subjects, taxons, collapse=";")
     }
-    all_subjects = paste(subjects, title_ngrams$bigrams, title_ngrams$trigrams, collapse=" ")
+    if (api == "linkedcat" || api == "linkedcat_authorview") {
+      all_subjects = paste(subjects, collapse=" ")
+    } else {
+      all_subjects = paste(subjects, title_ngrams$bigrams, title_ngrams$trigrams, collapse=" ")
+    }
     all_subjects = gsub(",", ";", all_subjects)
     subjectlist = c(subjectlist, all_subjects)
   }

--- a/server/preprocessing/other-scripts/test/base-test-ger.R
+++ b/server/preprocessing/other-scripts/test/base-test-ger.R
@@ -50,6 +50,7 @@ tryCatch({
 #time.taken
 tryCatch({
 output_json = vis_layout(input_data$text, input_data$metadata,
+                         service,
                          max_clusters = MAX_CLUSTERS,
                          lang = LANGUAGE,
                          add_stop_words = ADDITIONAL_STOP_WORDS,

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -55,7 +55,9 @@ tryCatch({
 #time.taken <- end.time - start.time
 #time.taken
 tryCatch({
-output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS,
+output_json = vis_layout(input_data$text, input_data$metadata,
+                         service,
+                         max_clusters=MAX_CLUSTERS,
                          lang=LANGUAGE$name,
                          add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
 }, error=function(err){

--- a/server/preprocessing/other-scripts/test/params_linkedcat.json
+++ b/server/preprocessing/other-scripts/test/params_linkedcat.json
@@ -1,5 +1,19 @@
 {
   "from":"1847",
   "to":"1918",
-  "include_content_type": ["Anthologie","Biografie","Briefsammlung","Katalog","Kommentar","Mitgliederverzeichnis","Quelle","Reisebericht","Rezension","Statistik","Verzeichnis"]
+  "include_content_type": [
+    "Andere Abhandlungen",
+    "Anthologie",
+    "Biografie",
+    "Briefsammlung",
+    "Katalog",
+    "Kommentar",
+    "Mehrsprachiges Wörterbuch",
+    "Mitgliederverzeichnis",
+    "Quelle",
+    "Reisebericht",
+    "Rezension",
+    "Statistik",
+    "Verzeichnis",
+    "Wörterbuch"]
 }

--- a/server/preprocessing/other-scripts/test/pubmed-test.R
+++ b/server/preprocessing/other-scripts/test/pubmed-test.R
@@ -55,13 +55,15 @@ tryCatch({
 #time.taken <- end.time - start.time
 #time.taken
 tryCatch({
-output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS,
-                         lang=LANGUAGE$name,
-                         add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
+  output_json = vis_layout(input_data$text, input_data$metadata,
+                           service,
+                           max_clusters=MAX_CLUSTERS,
+                           lang=LANGUAGE$name,
+                           add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
 }, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
+  tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
   failed$query <<- query
-  failed$query_reason <<- err$message
+  failed$processing_reason <<- err$message
 })
 
 if (!exists('output_json')) {

--- a/server/preprocessing/other-scripts/text_similarity.R
+++ b/server/preprocessing/other-scripts/text_similarity.R
@@ -95,9 +95,11 @@ tryCatch({
 
 print("got the input")
 tryCatch({
-output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS, add_stop_words=ADDITIONAL_STOP_WORDS,
-                         lang=LANGUAGE$name,
-                         taxonomy_separator=taxonomy_separator, list_size = list_size)
+  output_json = vis_layout(input_data$text, input_data$metadata,
+                           service,
+                           max_clusters=MAX_CLUSTERS, add_stop_words=ADDITIONAL_STOP_WORDS,
+                           lang=LANGUAGE$name,
+                           taxonomy_separator=taxonomy_separator, list_size = list_size)
 }, error=function(err){
  tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
  failed$query <<- query

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -21,7 +21,7 @@ vlog <- getLogger('vis')
 # Expects the following metadata fields:
 # id, content, title, readers, published_in, year, authors, paper_abstract, subject
 
-vis_layout <- function(text, metadata,
+vis_layout <- function(text, metadata, api,
                        max_clusters=15, maxit=500,
                        mindim=2, maxdim=2,
                        lang=NULL, add_stop_words=NULL,
@@ -76,7 +76,8 @@ vis_layout <- function(text, metadata,
 
   vlog$debug("get cluster summaries")
   metadata = replace_keywords_if_empty(metadata, stops)
-  named_clusters <- create_cluster_labels(clusters, metadata, lang,
+  named_clusters <- create_cluster_labels(clusters, metadata,
+                                          api, lang,
                                           corpus$unlowered,
                                           weightingspec="ntn", top_n=3,
                                           stops=stops, taxonomy_separator)


### PR DESCRIPTION
This PR introduce API-specific summarization:
* a new parameter "api" gets handed down from text-similarity through vis_layout to the cluster-wise summarization procedure
* at this stage it can be decided which tokens are taken into consideration for bubble-titles
* currently only for the linked-cat API a specific route has been implemented, other APIs remain unchanged
* the tests for base and pubmed have been updated to reflect the change in parameters

A few tests have been conducted on base, pubmed which continue to function unchanged; tests on linkedcat show the intended behavior on both authorview and keyword search. for full functionality on linkedcat #347 should be merged as well.