### PR TITLE
Update bootstrap-sass and webpack-dev-server version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/pkraker/Headstart#readme",
   "dependencies": {
     "bootstrap-loader": "^1.1.4",
-    "bootstrap-sass": "^3.3.6",
+    "bootstrap-sass": "^3.4.1",
     "d3": "^3.5.17",
     "font-awesome": "*",
     "handlebars": "^4.0.5",
@@ -53,7 +53,7 @@
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.11.2",
     "handlebars-loader": "*",
-	"hoek": "^5.0.3",
+    "hoek": "^5.0.3",
     "html-webpack-plugin": "*",
     "imports-loader": "^0.6.5",
     "node-sass": "3.13.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "style-loader": "0.19.1",
     "url-loader": "0.6.2",
     "webpack": "1.15.0",
-    "webpack-dev-server": "^1.14.1",
+    "webpack-dev-server": "^3.2.1",
     "webpack-merge": "*"
   }
 }


### PR DESCRIPTION
Updated bootstrap-sass and webpack-dev-server version in package.json,
`npm install` and `npm run dev` went through without complaints
and the viz renders correctly as far as I can see.
Would be great if you could double check how it works for you.

(I think npm fixed the indentation of the package.json, that's why the second change is in there. It shouldn't matter)