### PR TITLE
Linkedcat backend

### DIFF
--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -100,7 +100,13 @@ get_papers <- function(query, params, limit=100) {
 
 build_query <- function(query, params, limit){
   # fields to query in
-  q_fields <- c('main_title', 'ocrtext', 'author')
+  q_fields <- c('main_title', 'ocrtext',
+                'author100_a', 'author100_d', 'author100_0',
+                'author700_a', 'author700_d', 'author700_0',
+                'main_title', 'subtitle', 'pub_year',
+                'host_label', 'host_maintitle', 'host_pubplace', 'host_pubyear',
+                'bkl_caption', 'bkl_top_caption',
+                'keyword_a', 'tags')
   # fields to return
   r_fields <- c('id', 'idnr',
                 'content_type_a', 'content_type_2',

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -103,8 +103,8 @@ build_query <- function(query, params, limit){
   q_fields <- c('main_title', 'ocrtext',
                 'author100_a', 'author100_d', 'author100_0',
                 'author700_a', 'author700_d', 'author700_0',
-                'main_title', 'subtitle', 'pub_year',
-                'host_label', 'host_maintitle', 'host_pubplace', 'host_pubyear',
+                'main_title', 'subtitle',
+                'host_label', 'host_maintitle', 'host_pubplace',
                 'bkl_caption', 'bkl_top_caption',
                 'keyword_a', 'tags')
   # fields to return

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -122,15 +122,13 @@ build_query <- function(query, params, limit){
 
   # additional filter params
   pub_year <- paste0("pub_year:", "[", params$from, " TO ", params$to, "]")
-  if ("Bericht" %in% params$include_content_type) {
-    # false: neither Bericht nor Protokoll || only Bericht
-    if (!("Protokoll" %in% params$include_content_type) ||
-            (!("Protokoll" %in% params$include_content_type) && !("Bericht" %in% params$include_content_type) )) {
-      protocol_flag <- "protocol:false"
-    }
-    if ("Protokoll" %in% params$include_content_type) {
-      protocol_flag <- "protocol:true"
-    }
+  if (!("Protokoll" %in% params$include_content_type) ||
+          (!("Protokoll" %in% params$include_content_type) && !("Bericht" %in% params$include_content_type) )) {
+    protocol_flag <- "protocol:false"
+  }
+  if ("Protokoll" %in% params$include_content_type) {
+    protocol_flag <- "protocol:true"
+  }
   if (!params$include_content_type[1] == 'all') {
       if (length(params$include_content_type) > 1) {
         content_type <- paste0("content_type_a_str:(",

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -127,7 +127,7 @@ build_query <- function(query, params, limit){
     protocol_flag <- "protocol:false"
   }
   if ("Protokoll" %in% params$include_content_type) {
-    protocol_flag <- "protocol:true"
+    protocol_flag <- "protocol:(true or false)"
   }
   if (!params$include_content_type[1] == 'all') {
       if (length(params$include_content_type) > 1) {

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -122,6 +122,15 @@ build_query <- function(query, params, limit){
 
   # additional filter params
   pub_year <- paste0("pub_year:", "[", params$from, " TO ", params$to, "]")
+  if ("Bericht" %in% params$include_content_type) {
+    # false: neither Bericht nor Protokoll || only Bericht
+    if (!("Protokoll" %in% params$include_content_type) ||
+            (!("Protokoll" %in% params$include_content_type) && !("Bericht" %in% params$include_content_type) )) {
+      protocol_flag <- "protocol:false"
+    }
+    if ("Protokoll" %in% params$include_content_type) {
+      protocol_flag <- "protocol:true"
+    }
   if (!params$include_content_type[1] == 'all') {
       if (length(params$include_content_type) > 1) {
         content_type <- paste0("content_type_a_str:(",
@@ -130,9 +139,9 @@ build_query <- function(query, params, limit){
         } else {
         content_type <- paste0("content_type_a_str:", params$include_content_type, collapse = "")
       }
-    q_params$fq <- list(pub_year, content_type)
+    q_params$fq <- list(pub_year, content_type, protocol_flag)
   } else {
-    q_params$fq <- list(pub_year)
+    q_params$fq <- list(pub_year, protocol_flag)
   }
   q_params$fq <- unlist(q_params$fq)
   q_params$hl <- 'on'

--- a/server/preprocessing/other-scripts/test/linkedcat-test.R
+++ b/server/preprocessing/other-scripts/test/linkedcat-test.R
@@ -7,7 +7,7 @@ options(warn=1)
 wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
 setwd(wd) #Don't forget to set your working directory
 
-query <- "protokoll" #args[2]
+query <- "hund" #args[2]
 service <- "linkedcat"
 params <- NULL
 params_file <- "params_linkedcat.json"
@@ -49,6 +49,7 @@ tryCatch({
 
 tryCatch({
   output_json = vis_layout(input_data$text, input_data$metadata,
+                           service,
                            max_clusters = MAX_CLUSTERS,
                            lang = LANGUAGE,
                            add_stop_words = ADDITIONAL_STOP_WORDS,

--- a/server/preprocessing/other-scripts/test/linkedcat_authorview-test.R
+++ b/server/preprocessing/other-scripts/test/linkedcat_authorview-test.R
@@ -49,6 +49,7 @@ tryCatch({
 
 tryCatch({
   output_json = vis_layout(input_data$text, input_data$metadata,
+                           service,
                            max_clusters = MAX_CLUSTERS,
                            lang = LANGUAGE,
                            add_stop_words = ADDITIONAL_STOP_WORDS,

--- a/server/services/getLinkedCatAuthors.php
+++ b/server/services/getLinkedCatAuthors.php
@@ -20,6 +20,7 @@ $base_url = "https://" .
        $ini_array["connection"]["linkedcat_solr"] . "/solr/linkedcat/";
 
 $author_facet_query = "select?facet.field=author100_0_str" .
+                      "&facet.field=author700_0_str" .
                       "&facet.query=author100_0_str" .
                       "&facet=on&fl=author100_0_str" .
                       "&q=*:*&rows=0&facet.limit=-1&facet.sort=index";
@@ -42,7 +43,7 @@ function execQuery($base_url, $query) {
 
 function getAuthorFacet($base_url, $author_facet_query) {
   $res = json_decode(execQuery($base_url, $author_facet_query), true);
-  return $res["facet_counts"]["facet_fields"]["author100_0_str"];
+  return $res["facet_counts"]["facet_fields"];
 }
 
 function getAuthorData($base_url, $author_data_query, $author_ids) {
@@ -119,9 +120,23 @@ function getAuthors() {
                                  $GLOBALS['author_facet_query']);
   $author_ids = array();
   $author_counts = array();
-  foreach ($author_facet as $k => $v) {
+  foreach ($author_facet["author100_0_str"] as $k => $v) {
     if ($k % 2 == 0) {
       $author_ids[] = $v;
+    }
+    else {
+      $author_counts[] = $v;
+    }
+  }
+  foreach ($author_facet["author700_0_str"] as $k => $v) {
+    if ($k % 2 == 0) {
+      $pos = array_search($v, $author_ids);
+      if ($pos != false) {
+        $author_counts[$pos] += $author_facet["author700_0_str"][$k + 1];
+      }
+      else {
+        $author_ids[] = $v;
+      }
     }
     else {
       $author_counts[] = $v;


### PR DESCRIPTION
With this PR
* discrepancies between document counts in authorview-suggestions and actual maps are fixed; the getLinkedcatAuthors.php has been updated and now includes document counts from secondary authorship
* the range of fields which are queried is expanded - some can not be included (e.g. string search is not possible in year field which is integer)
* lastly, additional document selection logic has been added to better disambiguate between Berichte and Protokolls - this aspect has not been tested as it requires changes in the input from the search box