### PR TITLE
Linkedcat streamgraph backend - dynamic ranges

### DIFF
--- a/doc/server_config.md
+++ b/doc/server_config.md
@@ -46,6 +46,7 @@ Make sure you have the following packages installed:
   * textcat (for language recognition)
   * solrium (for interfacing with SOLR servers, install with `devtools::install_github("chreman/solrium")`)
   * tidyr
+  * forcats
 
 * phantomjs 2.1+ (http://phantomjs.org/), if you want to use the snapshot feature
 

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -77,8 +77,12 @@ sg_data = list()
 if (service == 'linkedcat' || service == 'linkedcat_authorview') {
   stream_range = list(min=min(metadata$year), max=max(metadata$year), range=max(metadata$year)-min(metadata$year))
   n_breaks = min(stream_range$range, 10)
-  metadata <- mutate(metadata, boundary_label=cut(metadata$year, n_breaks, include.lowest = TRUE, right=FALSE))
-  levels(metadata$boundary_label) <- rename_xaxis(metadata$boundary_label)
+  if (n_breaks > 10) {
+    metadata <- mutate(metadata, boundary_label=cut(metadata$year, n_breaks, include.lowest = TRUE, right=FALSE))
+    levels(metadata$boundary_label) <- rename_xaxis(metadata$boundary_label)
+  } else {
+    metadata$boundary_label <- as.factor(metadata$year)
+  }
   sg_data$x <- levels(metadata$boundary_label)
   sg_data$subject <- (metadata
                       %>% separate_rows(subject, sep="; ")

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -76,7 +76,7 @@ sg_data = list()
 
 if (service == 'linkedcat' || service == 'linkedcat_authorview') {
   stream_range = list(min=min(metadata$year), max=max(metadata$year), range=max(metadata$year)-min(metadata$year))
-  n_breaks = min(stream_range$range, 10)
+  n_breaks = min(stream_range$range, 11)
   if (n_breaks > 10) {
     metadata <- mutate(metadata, boundary_label=cut(metadata$year, n_breaks, include.lowest = TRUE, right=FALSE))
     levels(metadata$boundary_label) <- rename_xaxis(metadata$boundary_label)


### PR DESCRIPTION
This PR introduces dynamic ranges for the x-axis:
The procedure first looks at the total year-range of the map, if the range exceeds 10 years, the documents are binned into 10 evenly spread time slices. The cut-off value of 10 years and the number of 10 bins has been arbitrarily chosen and can be either changed to a different number, or defined in a dynamic way as well (which needs to be discussed).

The effect can be best seen by comparing an author-streamgraph (e.g. Hammer-Purgstall) with a subject-streamgraph (e.g. "wald").

* requires additional R package: install.packages('forcats')