### PR TITLE
Linkedcat backend

### DIFF
--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -35,9 +35,11 @@ post_process <- function(sg_data) {
     new_item <- list()
     new_item$name <- item
     tmp <- sg_data %>% subset(stream_item == item)
-    tmp <- (merge(tmp,
-                  data.frame(year=stream_range$min:stream_range$max), all=TRUE)
-            %>% replace_na(list(stream_item=item, count=0, ids="NA")))
+    if (n_breaks <= 10) {
+      tmp <- (merge(tmp,
+                    data.frame(year=stream_range$min:stream_range$max), all=TRUE)
+              %>% replace_na(list(stream_item=item, count=0, ids="NA")))
+    }
     new_item$y <- tmp$count
     new_item$ids_overall <- (tmp
                               %>% ungroup()
@@ -79,8 +81,8 @@ rename_xaxis <- function(boundary_label) {
 sg_data = list()
 
 if (service == 'linkedcat' || service == 'linkedcat_authorview') {
-  stream_range = list(min=min(metadata$year), max=max(metadata$year), range=max(metadata$year)-min(metadata$year))
-  n_breaks = min(stream_range$range, 11)
+  stream_range <- list(min=min(metadata$year), max=max(metadata$year), range=max(metadata$year)-min(metadata$year))
+  n_breaks <- min(stream_range$range, 11)
   if (n_breaks > 10) {
     metadata <- mutate(metadata, boundary_label=cut(metadata$year, n_breaks, include.lowest = TRUE, right=FALSE))
     levels(metadata$boundary_label) <- rename_xaxis(metadata$boundary_label)
@@ -89,40 +91,79 @@ if (service == 'linkedcat' || service == 'linkedcat_authorview') {
     levels(metadata$boundary_label) <- levels(as.factor(stream_range$min:stream_range$max))
   }
   sg_data$x <- levels(metadata$boundary_label)
-  sg_data$subject <- ((merge(metadata
-                           %>% select(boundary_label, year, subject, id)
-                           %>% separate_rows(subject, sep="; ")
-                           %>% rename(stream_item=subject)
-                           %>% mutate(count=1),
-                           metadata
-                           %>% select(boundary_label)
-                           %>% expand(boundary_label)
-                           %>% rename(year=boundary_label),
-                           all=TRUE))
-                    %>% group_by(year, stream_item, .drop=FALSE)
-                    %>% summarise(count=sum(count), ids=paste(id, collapse=", ")))
-  top_20 <-(sg_data$subject
+  if (n_breaks > 10) {
+    sg_data$subject <- (metadata
+                             %>% select(boundary_label, year, subject, id)
+                             %>% separate_rows(subject, sep="; ")
+                             %>% rename(stream_item=subject)
+                             %>% mutate(count=1)
+                             %>% group_by(boundary_label, stream_item, .drop=FALSE)
+                             %>% summarise(count=sum(count), ids=paste(id, collapse=", ")))
+  } else {
+    sg_data$subject <- (merge(metadata
+                              %>% select(boundary_label, year, subject, id)
+                              %>% separate_rows(subject, sep="; ")
+                              %>% rename(stream_item=subject)
+                              %>% mutate(count=1)
+                              %>% group_by(year, stream_item, .drop=FALSE)
+                              %>% summarise(count=sum(count), ids=paste(id, collapse=", ")),
+                              metadata
+                              %>% select(boundary_label, year)
+                              %>% distinct(),
+                              by.x = "year", by.y = "year"))
+  }
+  top_12_subject <- (sg_data$subject
             %>% group_by(stream_item)
             %>% summarise(sum = sum(count))
             %>% arrange(desc(sum))
             %>% drop_na()
-            %>% head(20)
+            %>% head(12)
             %>% select(stream_item)
             %>% pull())
-  sg_data$subject <- (sg_data$subject
-                      %>% subset(stream_item %in% top_20)
-                      %>% arrange(match(stream_item, top_20), year))
-  sg_data$area <- ((merge(metadata
-                     %>% select(boundary_label, year, area, id)
-                     %>% rename(stream_item=area)
-                     %>% mutate(count=1),
-                     metadata
-                     %>% select(boundary_label)
-                     %>% expand(boundary_label)
-                     %>% rename(year=boundary_label),
-                     all=TRUE))
-                   %>% group_by(year, stream_item, .drop=FALSE)
-                   %>% summarise(count=sum(count), ids=paste(id, collapse=", ")))
+  if (n_breaks > 10) {
+    sg_data$subject <- (sg_data$subject
+                        %>% subset(stream_item %in% top_12_subject)
+                        %>% arrange(match(stream_item, top_12_subject), boundary_label))
+  } else {
+    sg_data$subject <- (sg_data$subject
+                        %>% subset(stream_item %in% top_12_subject)
+                        %>% arrange(match(stream_item, top_12_subject), year))}
+  if (n_breaks > 10) {
+    sg_data$area <- (metadata
+                       %>% select(boundary_label, year, area, id)
+                       %>% rename(stream_item=area)
+                       %>% mutate(count=1)
+                       %>% group_by(boundary_label, stream_item, .drop=FALSE)
+                       %>% summarise(count=sum(count), ids=paste(id, collapse=", ")))
+  } else {
+    sg_data$area <- (merge(metadata
+                           %>% select(boundary_label, year, area, id)
+                           %>% rename(stream_item=area)
+                           %>% mutate(count=1)
+                           %>% group_by(year, stream_item, .drop=FALSE)
+                           %>% summarise(count=sum(count), ids=paste(id, collapse=", ")),
+                           metadata
+                           %>% select(boundary_label, year)
+                           %>% distinct(),
+                           by.x = "year", by.y = "year"))
+  }
+  top_12_area <- (sg_data$area
+           %>% group_by(stream_item)
+           %>% summarise(sum = sum(count))
+           %>% arrange(desc(sum))
+           %>% drop_na()
+           %>% head(12)
+           %>% select(stream_item)
+           %>% pull())
+  if (n_breaks > 10) {
+    sg_data$area <- (sg_data$area
+                        %>% subset(stream_item %in% top_12_area)
+                        %>% arrange(match(stream_item, top_12_area), boundary_label))
+  } else {
+    sg_data$area <- (sg_data$area
+                        %>% subset(stream_item %in% top_12_area)
+                        %>% arrange(match(stream_item, top_12_area), year))
+  }
   #sg_data$bkl_caption <- metadata %>% separate_rows(bkl_caption, sep="; ") %>% group_by(boundary_label, bkl_caption) %>% summarize(count = uniqueN(id), ids = list(unique(id)))
   output <- list()
   output$x <- sg_data$x

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -39,6 +39,10 @@ post_process <- function(sg_data) {
       tmp <- (merge(tmp,
                     data.frame(year=stream_range$min:stream_range$max), all=TRUE)
               %>% replace_na(list(stream_item=item, count=0, ids="NA")))
+    } else {
+      tmp <- (merge(tmp,
+                    tmp %>% expand(boundary_label), all=TRUE)
+              %>% replace_na(list(stream_item=item, count=0, ids="NA")))
     }
     new_item$y <- tmp$count
     new_item$ids_overall <- (tmp


### PR DESCRIPTION
This PR
* fixes a bug where in some cases data was erroneously added to the x-axis. this is done by now explicitly handling the two cases of aggregated and non-aggregated years separately at all stages
* additionally, for both bubble areas and keyword-streamgraphs a top_12 filter was implemented