### PR TITLE
Linkedcat keyword streamgraphs

### DIFF
--- a/examples/linkedcat/search_options.js
+++ b/examples/linkedcat/search_options.js
@@ -28,7 +28,13 @@ var options_linkedcat = {
                 , {id: "Statistik", text: "Statistik", count:2, selected:true}
                 , {id: "Verzeichnis", text: "Verzeichnis", count:43, selected:true}
                 , {id: "Wörterbuch", text: "Wörterbuch", count:15, selected:true}
-            ]},
+              ]},
+          {id: "vis_type", multiple: false, name: "Visualisierungstypen", type: "dropdown"
+              , fields: [
+                  {id: "overview", text: "Überblick", selected:true}
+                  , {id: "timeline", text: "Zeitstrahl"}
+              ]},
+      ]
     ]
 }
 
@@ -72,7 +78,7 @@ var SearchOptions = {
                         return 'divity frontend-hidden';
                     } else {
                         return 'divity';
-                    } 
+                    }
                 })
 
         d3.select(tag).append('div')
@@ -118,7 +124,7 @@ var SearchOptions = {
                     var current_option = new_select
                             .append('option')
                             .attr("value", option.id)
-                            .text(option.text 
+                            .text(option.text
                                     + ((typeof option.count !== "undefined")?(" (" + option.count + ")"):(""))
                                 );
 
@@ -131,11 +137,11 @@ var SearchOptions = {
                         option.inputs.forEach(function (input) {
                             let input_container = d3.select("#input-container")
                                     .append('div').attr('class','timefield')
-                                
+
                                 input_container.append("label")
                                     .attr("for", input.id)
                                     .text(input.label)
-                                    
+
                                 input_container.append("input")
                                     .attr("id", input.id)
                                     .attr("name", input.id)

--- a/examples/linkedcat/search_options.js
+++ b/examples/linkedcat/search_options.js
@@ -34,7 +34,6 @@ var options_linkedcat = {
                   {id: "overview", text: "Überblick", selected:true}
                   , {id: "timeline", text: "Zeitstrahl"}
               ]},
-      ]
     ]
 }
 

--- a/server/preprocessing/other-scripts/preprocess.R
+++ b/server/preprocessing/other-scripts/preprocess.R
@@ -74,7 +74,7 @@ deduplicate_titles <- function(metadata, list_size) {
 replace_keywords_if_empty <- function(metadata, stops, service) {
   missing_subjects = which(lapply(metadata$subject, function(x) {nchar(x)}) <= 1)
   if (service == "linkedcat" || service == "linkedcat_authorview") {
-    metadata$subject[missing_subjects] <- metadata$bkl_caption
+    metadata$subject[missing_subjects] <- metadata$bkl_caption[missing_subjects]
   } else {
     candidates = mapply(paste, metadata$title[missing_subjects])
     candidates = lapply(candidates, function(x)paste(removeWords(x, stops), collapse=""))

--- a/server/preprocessing/other-scripts/text_similarity.R
+++ b/server/preprocessing/other-scripts/text_similarity.R
@@ -27,6 +27,19 @@ tslog <- getLogger('ts')
 source(paste("../other-scripts/vis_layout.R", sep=""))
 source('../other-scripts/altmetrics.R')
 
+
+if(!is.null(params_file) && !is.na(params_file)) {
+  params <- fromJSON(params_file)
+} else {
+  params <- NULL
+}
+
+if (!is.null(params$lang_id)) {
+    lang_id <- params$lang_id
+  } else {
+    lang_id <- 'all'
+}
+
 taxonomy_separator = NULL
 limit = 100
 list_size = -1
@@ -51,6 +64,7 @@ switch(service,
        },
        linkedcat={
          source('../other-scripts/linkedcat.R')
+         limit = ifelse(params$vis_type=='timeline', 9999, 100)
        },
        linkedcat_authorview={
          source('../other-scripts/linkedcat_authorview.R')
@@ -61,23 +75,9 @@ switch(service,
       }
 )
 
-
-MAX_CLUSTERS = 15
-
 print("inhere")
 
-if(!is.null(params_file) && !is.na(params_file)) {
-  params <- fromJSON(params_file)
-} else {
-  params <- NULL
-}
-
-if (!is.null(params$lang_id)) {
-    lang_id <- params$lang_id
-  } else {
-    lang_id <- 'all'
-}
-
+MAX_CLUSTERS = 15
 LANGUAGE <- get_service_lang(lang_id, valid_langs, service)
 ADDITIONAL_STOP_WORDS = LANGUAGE$name
 

--- a/server/services/searchLinkedCat.php
+++ b/server/services/searchLinkedCat.php
@@ -11,7 +11,7 @@ $dirty_query = library\CommUtils::getParameter($_POST, "q");
 
 $post_params = $_POST;
 
-$result = search("linkedcat", $dirty_query, $post_params, array("from", "to", "include_content_type", "today", "streamgraph"), ";", null);
+$result = search("linkedcat", $dirty_query, $post_params, array("from", "to", "include_content_type", "today", "vis_type"), ";", null);
 
 echo $result
 

--- a/server/services/searchLinkedCat.php
+++ b/server/services/searchLinkedCat.php
@@ -11,7 +11,7 @@ $dirty_query = library\CommUtils::getParameter($_POST, "q");
 
 $post_params = $_POST;
 
-$result = search("linkedcat", $dirty_query, $post_params, array("from", "to", "include_content_type", "today"), ";", null);
+$result = search("linkedcat", $dirty_query, $post_params, array("from", "to", "include_content_type", "today", "streamgraph"), ";", null);
 
 echo $result
 


### PR DESCRIPTION
This PR adds functionality to create streamgraphs separately from overview maps.
* In the search options, a visualization type selector is re-implemented
* searchLinkedCat now has a vis_type parameter, taken from search_options and relayed to text_similarity
* text_similarity is modified to parse params first, before setting workflow params, as some workflow params will depend on the selected option
* an additional small bugfix for missing keyword replacement has been smuggled in