### PR TITLE
fixed keyword replacement for single doc bubbles

### DIFF
--- a/server/preprocessing/other-scripts/preprocess.R
+++ b/server/preprocessing/other-scripts/preprocess.R
@@ -73,7 +73,6 @@ deduplicate_titles <- function(metadata, list_size) {
 
 replace_keywords_if_empty <- function(metadata, stops, service) {
   missing_subjects = which(lapply(metadata$subject, function(x) {nchar(x)}) <= 1)
-
   if (service == "linkedcat" || service == "linkedcat_authorview") {
     metadata$subject[missing_subjects] <- metadata$bkl_caption[missing_subjects]
   } else {

--- a/server/preprocessing/other-scripts/preprocess.R
+++ b/server/preprocessing/other-scripts/preprocess.R
@@ -73,10 +73,11 @@ deduplicate_titles <- function(metadata, list_size) {
 
 replace_keywords_if_empty <- function(metadata, stops, service) {
   missing_subjects = which(lapply(metadata$subject, function(x) {nchar(x)}) <= 1)
+
   if (service == "linkedcat" || service == "linkedcat_authorview") {
     metadata$subject[missing_subjects] <- metadata$bkl_caption[missing_subjects]
   } else {
-    candidates = mapply(paste, metadata$title[missing_subjects])
+    candidates = mapply(paste, metadata$title)
     candidates = lapply(candidates, function(x)paste(removeWords(x, stops), collapse=""))
     candidates = lapply(candidates, function(x) {gsub("[^[:alpha:]]", " ", x)})
     candidates = lapply(candidates, function(x) {gsub(" +", " ", x)})
@@ -93,7 +94,7 @@ replace_keywords_if_empty <- function(metadata, stops, service) {
     replacement_keywords = lapply(replacement_keywords, FUN = function(x) {paste(unlist(x), collapse=";")})
     replacement_keywords = gsub("_", " ", replacement_keywords)
 
-    metadata$subject[missing_subjects] <- replacement_keywords
+    metadata$subject[missing_subjects] <- replacement_keywords[missing_subjects]
   }
   return(metadata)
 }


### PR DESCRIPTION
This PR fixes the occurence of empty bubbles in cases containing only one paper which is additionally missing keywords. Previously, no replacement keywords could be generated as only documents with missing keywords were considered.

Now all documents of a map will be considered for replacement keyword generation (change in L79) while only the documents with missing keywords will be replaced (change in L96).

The effect can be seen in the map for "financial distress" on PubMed with the search range 5 Feb 2019 - 12 Feb 2019.
Additionally, minimal differences may occur in maps with documents which lack keywords, as can be seen in the BASE map of digital education. In general, this may be an improvement, since missing keywords will be replaced with the whole map in mind, leading to them being more representative.