### PR TITLE
Linkedcat browseview backend

### DIFF
--- a/server/preprocessing/conf/config.ini
+++ b/server/preprocessing/conf/config.ini
@@ -47,6 +47,7 @@ linkedcat_solr = ""
 linkedcat_user = ""
 linkedcat_pwd = ""
 linkedcat_suggest_cache = "/path/to/server/storage/lc_cache.json"
+linkedcat_browseview_cache = "/path/to/server/storage/lc_browseview_cache.json"
 
 [calculation]
 # Path to the RScript binary

--- a/server/preprocessing/other-scripts/linkedcat_browseview.R
+++ b/server/preprocessing/other-scripts/linkedcat_browseview.R
@@ -1,0 +1,128 @@
+library(solrium)
+library(plyr)
+
+# get_papers
+#
+# Params:
+#
+# * query: search query
+# * params: parameters for the search in JSON format
+#    * from: publication date lower bound in the form YYYY-MM-DD
+#    * to: publication date upper bound in the form YYYY-MM-DD
+#    * article_types: in the form of an array of identifiers of article types
+#    * sorting: can be one of "most-relevant" and "most-recent"
+# * limit: number of search results to return
+#
+# It is expected that get_papers returns a list containing two data frames named "text" and "metadata"
+#
+# "text" contains the text for similarity analysis; it is expected to have two columns "id" and "content"
+#
+# "metadata" contains all metadata; its columns are expected to be named as follows:
+# * "id": a unique ID, preferably the DOI
+# * "title": the title
+# * "authors": authors, preferably in the format "LASTNAME1, FIRSTNAME1;LASTNAME2, FIRSTNAME2"
+# * "paper_abstract": the abstract
+# * "published_in": name of the journal or venue
+# * "year": publication date
+# * "url": URL to the landing page
+# * "readers": an indicator of the paper's popularity, e.g. number of readers, views, downloads etc.
+# * "subject": keywords or classification, split by ;
+# * "oa_state": open access status of the item; has the following possible states: 0 for no, 1 for yes, 2 for unknown
+# * "link": link to the PDF; if this is not available, a list of candidate URLs that may contain a link to the PDF
+
+
+lclog <- getLogger('api.linkedcat')
+
+
+get_papers <- function(query, params, limit=100) {
+
+  lclog$info(paste("Search: ", query, sep=""))
+  start.time <- Sys.time()
+  host=paste0(Sys.getenv("LINKEDCAT_USER"),":",Sys.getenv("LINKEDCAT_PWD"),"@",Sys.getenv("LINKEDCAT_SOLR"))
+  conn <- SolrClient$new(host=host,
+                         path="solr/linkedcat2", port=NULL, scheme="https")
+
+  q_params <- build_query(query, params, limit)
+  # do search
+  lclog$info(paste("Query:", paste(q_params, collapse = " ")))
+
+  res <- solr_all(conn, "linkedcat2", params = q_params, concat="; ")
+
+  if (nrow(res$search) == 0){
+    stop(paste("No results retrieved."))
+  }
+
+  # make results dataframe
+  search_res = res$search
+  metadata <- data.frame(search_res$id)
+  names(metadata) <- c('id')
+
+  metadata$subject <- paste(search_res$keyword_a, search_res$keyword_c,
+                            search_res$keyword_g, search_res$keyword_t,
+                            search_res$keyword_p, search_res$keyword_x,
+                            search_res$keyword_z)
+  metadata$subject <- unlist(lapply(metadata$subject, function(x) {gsub("; $", "", x)}))
+  metadata$subject <- unlist(lapply(metadata$subject, function(x) {gsub("; ; ", "; ", x)}))
+  metadata$subject <- unlist(lapply(metadata$subject, function(x) {gsub("[ ]{2,}", "", x)}))
+  metadata$authors <- paste(search_res$author100_a, search_res$author700_a, sep="; ")
+  metadata$authors <- unlist(lapply(metadata$authors, function(x) {gsub("; $|,$", "", x)}))
+  metadata$authors <- unlist(lapply(metadata$authors, function(x) {gsub("^; ", "", x)}))
+  metadata$author_date <- metadata$author100_d
+  metadata$title <- if (!is.null(search_res$main_title)) search_res$main_title else ""
+  metadata$paper_abstract <- if (!is.null(search_res$ocrtext)) unlist(lapply(search_res$ocrtext, substr, start=0, stop=1000)) else ""
+  metadata$year <- search_res$pub_year
+  metadata$readers <- 0
+  metadata$url <- search_res$id
+  metadata$link <- "" # needs fix
+  metadata$published_in <- paste(search_res$host_maintitle, search_res$host_pubyear, search_res$host_pubplace, sep=", ")
+  metadata$published_in <- unlist(lapply(metadata$published_in, function(x) {gsub(", $|, , ", "", x)}))
+  metadata$oa_state <- unlist(lapply(search_res$copyright_until, function(x) {if (x=="") 1 else 0}))
+  metadata$subject_orig = metadata$subject
+  metadata$relevance = c(nrow(metadata):1)
+  metadata$bkl_caption = if (!is.null(search_res$bkl_caption)) search_res$bkl_caption else ""
+  metadata$bkl_top_caption = if (!is.null(search_res$bkl_top_caption)) search_res$bkl_top_caption else ""
+
+  text = data.frame(matrix(nrow=nrow(metadata)))
+  text$id = metadata$id
+  # Add all keywords, including classification to text
+  text$content = paste(search_res$main_title, search_res$keyword_a,
+                       sep = " ")
+
+
+  ret_val=list("metadata" = metadata, "text" = text)
+
+  end.time <- Sys.time()
+  time.taken <- end.time - start.time
+  lclog$info(paste("Time taken:", time.taken, sep = " "))
+
+  return(ret_val)
+
+}
+
+build_query <- function(query, params, limit, bkl_level){
+  # fields to query in
+  q_field <- if (bkl_level == 'top') 'bkl_top_caption' else 'bkl_caption'
+  q_fields <- c('author100_a', 'author100_d', 'author100_0',
+                'author700_a', 'author700_d', 'author700_0')
+  # fields to return
+  r_fields <- c('id', 'idnr',
+                'content_type_a', 'content_type_2',
+                'main_title', 'subtitle', 'pub_year', 'copyright_until',
+                'host_maintitle', 'host_pubplace', 'host_pubyear',
+                'pub_place', 'pub_name', 'pub_date',
+                'author100_a', 'author100_d', 'author100_0', 'author100_4',
+                'author700_a', 'author700_d', 'author700_0',
+                'bkl_caption', 'bkl_top_caption',
+                'keyword_a', 'keyword_c', 'keyword_g', 'keyword_t',
+                'keyword_p', 'keyword_x', 'keyword_z',
+                'tags', 'category', 'bib', 'language_code',
+                'ocrtext')
+  q <- paste(paste0(q_field, ':', '"', params$bkl_list, '"'), collapse = " OR ")
+  q_params <- list(q = q, rows = limit, fl = r_fields)
+  return(q_params)
+}
+
+
+valid_langs <- list(
+    'ger'='german'
+)

--- a/server/preprocessing/other-scripts/linkedcat_browseview.R
+++ b/server/preprocessing/other-scripts/linkedcat_browseview.R
@@ -102,8 +102,6 @@ get_papers <- function(query, params, limit=100) {
 build_query <- function(query, params, limit){
   # fields to query in
   q_field <- if (params$bkl_level == 'top') 'bkl_top_caption' else 'bkl_caption'
-  q_fields <- c('author100_a', 'author100_d', 'author100_0',
-                'author700_a', 'author700_d', 'author700_0')
   # fields to return
   r_fields <- c('id', 'idnr',
                 'content_type_a', 'content_type_2',

--- a/server/preprocessing/other-scripts/linkedcat_browseview.R
+++ b/server/preprocessing/other-scripts/linkedcat_browseview.R
@@ -99,9 +99,9 @@ get_papers <- function(query, params, limit=100) {
 
 }
 
-build_query <- function(query, params, limit, bkl_level){
+build_query <- function(query, params, limit){
   # fields to query in
-  q_field <- if (bkl_level == 'top') 'bkl_top_caption' else 'bkl_caption'
+  q_field <- if (params$bkl_level == 'top') 'bkl_top_caption' else 'bkl_caption'
   q_fields <- c('author100_a', 'author100_d', 'author100_0',
                 'author700_a', 'author700_d', 'author700_0')
   # fields to return

--- a/server/preprocessing/other-scripts/test/linkedcat_browseview-test.R
+++ b/server/preprocessing/other-scripts/test/linkedcat_browseview-test.R
@@ -1,0 +1,61 @@
+rm(list = ls())
+
+library(rstudioapi)
+
+options(warn=1)
+
+wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
+setwd(wd) #Don't forget to set your working directory
+
+query <- "Chemische Technik" #args[2]
+service <- "linkedcat_browseview"
+params <- NULL
+params_file <- "params_linkedcat_browseview.json"
+
+source('../utils.R')
+DEBUG = FALSE
+
+if (DEBUG==TRUE){
+  setup_logging('DEBUG')
+} else {
+  setup_logging('INFO')
+}
+
+tslog <- getLogger('ts')
+
+source("../vis_layout.R")
+source('../linkedcat_browseview.R')
+
+
+MAX_CLUSTERS = 15
+LANGUAGE = "german"
+ADDITIONAL_STOP_WORDS = "german"
+
+if(!is.null(params_file)) {
+  params <- fromJSON(params_file)
+}
+
+#start.time <- Sys.time()
+
+tryCatch({
+  input_data = get_papers(query, params, limit=500)
+}, error=function(err){
+  tslog$error(gsub("\n", " ", paste("Query failed", service, query, paste(params, collapse=" "), err, sep="||")))
+})
+
+#end.time <- Sys.time()
+#time.taken <- end.time - start.time
+#time.taken
+
+tryCatch({
+  output_json = vis_layout(input_data$text, input_data$metadata,
+                           service,
+                           max_clusters = MAX_CLUSTERS,
+                           lang = LANGUAGE,
+                           add_stop_words = ADDITIONAL_STOP_WORDS,
+                           testing=TRUE, list_size=-1)
+}, error=function(err){
+  tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
+})
+
+print(output_json)

--- a/server/preprocessing/other-scripts/test/params_linkedcat_browseview.json
+++ b/server/preprocessing/other-scripts/test/params_linkedcat_browseview.json
@@ -1,0 +1,5 @@
+{
+  "bkl_level": "top",
+  "bkl_list": ["Chemische Technik"],
+  "doc_count": 7
+}

--- a/server/preprocessing/other-scripts/test/params_linkedcat_browseview.json
+++ b/server/preprocessing/other-scripts/test/params_linkedcat_browseview.json
@@ -1,5 +1,5 @@
 {
   "bkl_level": "top",
-  "bkl_list": ["Chemische Technik"],
-  "doc_count": 7
+  "bkl_list": ["Naturwissenschaften allgemein","Volkswirtschaft","Geisteswissenschaften allgemein","Psychologie","Chemische Technik","Umweltforschung","Bildungswesen","Bauwesen","Bergbau","Soziologie","Maschinenbau","Pädagogik","Sport","Verkehrswesen","Hauswirtschaft","Sozialwissenschaften allgemein","Verwaltungslehre"],
+  "doc_count": 76
 }

--- a/server/preprocessing/other-scripts/text_similarity.R
+++ b/server/preprocessing/other-scripts/text_similarity.R
@@ -70,6 +70,10 @@ switch(service,
          source('../other-scripts/linkedcat_authorview.R')
          limit = 500
        },
+       linkedcat_browseview={
+         source('../other-scripts/linkedcat_browseview.R')
+         limit = 500
+       },
       {
         source("../other-scripts/rplos_fast.R")
       }

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -151,10 +151,10 @@ function getBrowseTree() {
   $bkls_top_counts = array();
   foreach ($bkls_top_facet["bkl_top_caption"] as $k => $v) {
     if ($k % 2 == 0) {
-      $bkls_top[] = $v;
-    }
-    else {
-      $bkls_top_counts[] = $v;
+      if (strlen($v) > 0) {
+        $bkls_top[] = $v;
+        $bkls_top_counts[] = $bkls_top_facet["bkl_top_caption"][$k+1];
+      }
     }
   }
   array_multisort($bkls_top_counts, SORT_DESC, $bkls_top);

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -175,7 +175,7 @@ function getBrowseTree() {
     $bkl_facet = $bkl_facetdata[$bkl_top];
     $bkl_tree[] = array("bkl_top_caption" => $bkl_top,
                         "count" => $bkl_top_count,
-                        "bkl_facet" => $bkl_facet
+                        "bkl_facet" => $bkl_facet,
                         "map_link" => $map_link);
   }
   return json_encode($bkl_tree, JSON_UNESCAPED_UNICODE);

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -170,9 +170,7 @@ function getBrowseTree() {
     $bkl_facet = $bkl_facetdata[$bkl_top];
     $bkl_top_count = $bkls_top_counts[$i];
     $top_map_link = "";
-    $bkl_top_rest = array();
-    $bkl_top_rest_cumsum = 0;
-    if ($bkl_top_count >100) {
+    if ($bkl_top_count > 100) {
       $bkl_rest = array();
       $bkl_rest_cumsum = 0;
       foreach ($bkl_facet as $i => $bkl) {
@@ -181,7 +179,7 @@ function getBrowseTree() {
                                    array($bkl["bkl_caption"]),
                                    "bkl",
                                    $bkl["count"]);
-          $$bkl_facet[$i]["map_link"] = $map_link;
+          $bkl_facetdata[$bkl_top][$i]["map_link"] = $map_link ;
         } else {
           $bkl_rest[] = $bkl["bkl_caption"];
           $bkl_rest_cumsum += $bkl["count"];
@@ -197,7 +195,7 @@ function getBrowseTree() {
       $bkl_tree[] = array("bkl_top_caption" => $bkl_top,
                           "count" => $bkl_top_count,
                           "bkl_facet" => $bkl_facet,
-                          "map_link" => $rest_map_link);
+                          "map_link" => $map_link);
     }
     if ($bkl_top_count >= 10 and $bkl_top_count <= 100) {
       $map_link = buildMaplink($GLOBALS['search_url'],

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -167,6 +167,7 @@ function getBrowseTree() {
     $bkl_top_count = $bkls_top_counts[$i];
     $top_map_params = "";
     if ($bkl_top_count > 100) {
+      $cleaned_bkl = array();
       $bkl_rest = array();
       $bkl_rest_cumsum = 0;
       foreach ($bkl_facet as $i => $bkl) {
@@ -175,7 +176,9 @@ function getBrowseTree() {
                                    array($bkl["bkl_caption"]),
                                    "bkl",
                                    $bkl["count"]);
-          $bkl_facetdata[$bkl_top][$i]["map_params"] = $map_params ;
+          $cleaned_bkl[] = array("bkl_caption" => $bkl["bkl_caption"],
+                                 "count" => $bkl["count"],
+                                 "map_params" => $map_params);
         } else {
           $bkl_rest[] = $bkl["bkl_caption"];
           $bkl_rest_cumsum += $bkl["count"];
@@ -185,9 +188,9 @@ function getBrowseTree() {
                                $bkl_rest,
                                "bkl",
                                $bkl_rest_cumsum);
-      $bkl_facet[] = array("bkl_caption" => implode("; ", $bkl_rest),
-                           "count" => $bkl_rest_cumsum,
-                           "map_params" => "");
+      $cleaned_bkl[] = array("bkl_caption" => implode("; ", $bkl_rest),
+                             "count" => $bkl_rest_cumsum,
+                             "map_params" => $rest_map_params);
       $bkl_facet = array_filter($bkl_facet, function ($bkl) {
                                 return ($bkl["count"] >= 10);
                               });

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -1,0 +1,192 @@
+<?php
+
+# currently returns a list of lists:
+# [["(DE-588)11881835X","Pfizmaier, August",186,"1808-1887"],
+#  ["(DE-588)118545426","Hammer-Purgstall, Joseph <<von>>",83,"1774-1856"]]
+
+header('Content-type: application/json');
+
+require_once dirname(__FILE__) . '/../classes/headstart/library/CommUtils.php';
+require_once dirname(__FILE__) . '/../classes/headstart/library/toolkit.php';
+
+use headstart\library;
+
+$INI_DIR = dirname(__FILE__) . "/../preprocessing/conf/";
+$ini_array = library\Toolkit::loadIni($INI_DIR);
+
+$base_url = "https://" .
+       $ini_array["connection"]["linkedcat_user"] . ":" .
+       $ini_array["connection"]["linkedcat_pwd"] . "@" .
+       $ini_array["connection"]["linkedcat_solr"] . "/solr/linkedcat2/";
+
+#bkl_top_caption
+$bkl_top_query = "select?facet.field=bkl_top_caption" .
+                  "&q=*:*&rows=0&facet.limit=-1&facet.sort=index";
+
+$bkl_query = "select?facet.field=bkl_caption" .
+             "&facet=on&q=*:*&rows=0" .
+             "&fq=bkl_top_caption:";
+
+# &fq=bkl_top_caption:"Einzelne Sprachen und Literaturen"
+
+function execQuery($base_url, $query) {
+  $ch = curl_init();
+  curl_setopt_array($ch, array(
+      CURLOPT_RETURNTRANSFER => 1,
+      CURLOPT_URL => $base_url . $query
+  ));
+  $jsonData = curl_exec($ch);
+  curl_close($ch);
+  return $jsonData;
+}
+
+function getBkltopFacet($base_url, $bkl_top_query) {
+  $res = json_decode(execQuery($base_url, $author_facet_query), true);
+  return $res["facet_counts"]["facet_fields"];
+}
+
+function getBklFacet($base_url, $bkl_query, $bkls_top) {
+  $window = 100;
+  $res = array();
+  $mh = curl_multi_init();
+  $urls = array();
+  foreach ($bkls_top as $i => $bkl_top) {
+    if (strlen($bkl_top) > 0) {
+      $target = rawurlencode('"' . $bkl_top . '"');
+      $fetchURL = $base_url . $bkl_query . $target;
+      $urls[] = $fetchURL;
+    }
+  }
+
+  # setup initial window slice
+  for ($i = 0; $i < $window; $i++) {
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, array_shift($urls));
+    curl_setopt($ch, CURLOPT_HEADER, 0);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_multi_add_handle($mh, $ch);
+  }
+  do {
+    while (($mrc = curl_multi_exec($mh, $active)) == CURLM_CALL_MULTI_PERFORM)
+    if ($mrc != CURLM_OK) break;
+    # do stuff with the completed request
+    while ($done = curl_multi_info_read($mh)) {
+      $info = curl_getinfo($done['handle']);
+      if ($info['http_code'] == 200) {
+        # process response
+        $content = curl_multi_getcontent($done['handle']);
+        $content = json_decode($content, true);
+        if (isset($content["facet_counts"]["facet_fields"]["bkl_caption"])) {
+          $bkl_top = explode(":", $content["responseHeader"]["params"]["fq"])[1];
+          $res[$bkl_top] = array();
+          $bkls = array();
+          $bkl_counts();
+          foreach ( $content["facet_counts"]["facet_fields"]["bkl_caption"] as $k => $v) {
+            if ($k % 2 == 0) {
+              $bkls[] = $v;
+            }
+            else {
+              $bkl_counts[] = $v;
+            }
+          }
+          foreach ($bkls as $i => $bkl) {
+            $res[$bkl_top]["bkl_facet"][] = array("bkl_caption" => $bkl) + array("count" => $bkl_counts[$i]);
+            }
+          }
+
+        # add new author to request stack until author_ids is exhausted
+        $next_url = array_shift($urls);
+        # requests terminate prematurely in CURLM_OK check at invalid author query
+        # which comes from the author facet for ""
+        if (isset($next_url)) {
+          $ch = curl_init();
+          curl_setopt($ch, CURLOPT_URL, $next_url);
+          curl_setopt($ch, CURLOPT_HEADER, 0);
+          curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+          curl_multi_add_handle($mh, $ch);
+        }
+      # remove finished one
+      curl_multi_remove_handle($mh, $done['handle']);
+    } else {
+      curl_multi_remove_handle($mh, $done['handle']);
+      $ch = curl_init();
+      curl_setopt($ch, CURLOPT_URL, $info["url"]);
+      curl_setopt($ch, CURLOPT_HEADER, 0);
+      curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+      curl_multi_add_handle($mh, $ch);
+    }
+    }
+  } while ($active);
+  curl_multi_close($mh);
+  return $res;
+}
+
+function getBrowseTree() {
+  # first get facet counts of bkl_top_caption
+  # -> list of top_basisklassen and their document count
+  $bkls_top_facet = getBkltopFacet($GLOBALS['base_url'],
+                                 $GLOBALS['$bkl_top_query']);
+  $bkls_top = array();
+  $bkls_top_counts();
+  foreach ( $bkls_top_facet["bkl_top_caption"] as $k => $v) {
+    if ($k % 2 == 0) {
+      $bkls_top[] = $v;
+    }
+    else {
+      $bkls_top_counts[] = $v;
+    }
+  }
+  # build tree
+  $bkl_tree = array();
+  # multicurl bkl_facet for top_bkls
+  foreach ($bkls_top as $i => $bkl_top) {
+    $bkl_facet = getBklFacet($GLOBALS['base_url'],
+                             $GLOBALS['$bkl_query'],
+                             $bkls_top);
+  }
+  return json_encode($authors, JSON_UNESCAPED_UNICODE);
+}
+
+
+function loadCache($fname) {
+  $json = file_get_contents($fname);
+  return $json;
+}
+
+function writeCache($fname, $output) {
+  $fp = fopen($fname, 'w');
+  fwrite($fp, $output);
+  fclose($fp);
+}
+
+function loadOrRefresh($lc_cache) {
+  # checks if file exists AND if its fresher than 24h
+  # if true && true, load the cached file
+  if (file_exists($lc_cache) && (time() - filemtime($lc_cache) < 86400)) {
+    $bkl_tree = loadCache($lc_cache);
+  }
+  else {
+    # if one is false, create from SOLR and store in cache file
+    try {
+      $bkl_tree = getBrowseTree();
+      # if no error occurred, update cache
+      writeCache($lc_cache, $bkl_tree);
+    }
+    # if error in getting authors occurs, catch error
+    catch (exception $e) {
+      $msg = "LinkedCat browse view tree could not be loaded or created. Possible reason: " . $e->getMessage();
+      # if error occurred, skip cache refreshment at this stage and load instead
+      if (file_exists($lc_cache)) {
+          $bkl_tree = loadCache($lc_cache);
+      } else {
+        $bkl_tree = array();
+        $bkl_tree["error"] = $msg;
+        $bkl_tree = json_encode($bkl_tree);
+      }
+    }
+  }
+  return $bkl_tree;
+}
+
+$lc_cache = $ini_array["connection"]["linkedcat_browseview_cache"];
+echo loadOrRefresh($lc_cache);

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -80,7 +80,7 @@ function getBklFacetData($base_url, $bkl_query, $bkls_top) {
         $content = curl_multi_getcontent($done['handle']);
         $content = json_decode($content, true);
         if (isset($content["facet_counts"]["facet_fields"]["bkl_caption"])) {
-          $bkl_top = explode(":", $content["responseHeader"]["params"]["fq"])[1];
+          $bkl_top = str_replace('"', '', explode(":", $content["responseHeader"]["params"]["fq"])[1]);
           $bkls = array();
           $bkl_counts = array();
           foreach ($content["facet_counts"]["facet_fields"]["bkl_caption"] as $k => $v) {
@@ -95,7 +95,7 @@ function getBklFacetData($base_url, $bkl_query, $bkls_top) {
           $res[$bkl_top] = array();
           foreach ($bkls as $i => $bkl) {
             if ($bkl_counts[$i] > 0) {
-              $res[$bkl_top][] = array("bkl" => $bkl) + array("count" => $bkl_counts[$i]);
+              $res[$bkl_top][] = array("bkl_caption" => $bkl) + array("count" => $bkl_counts[$i]);
             }
           }
         }
@@ -146,13 +146,12 @@ function getBrowseTree() {
   $bkl_facetdata = getBklFacetData($GLOBALS['base_url'],
                                    $GLOBALS['bkl_query'],
                                    $bkls_top);
-  print_r($bkl_facetdata);
   # build tree
   $bkl_tree = array();
   foreach ($bkls_top as $i => $bkl_top) {
     $bkl_top_count = $bkls_top_counts[$i];
-    $bkl_facet = $bkl_facetdata[$bkl_top]["bkl_facet"];
-    $bkl_tree[] = array($bkl_top => $bkl_top_count) + array("bkl_facet" => $bkl_facet);
+    $bkl_facet = $bkl_facetdata[$bkl_top];
+    $bkl_tree[] = array("bkl_top_caption" => $bkl_top) + array("count" => $bkl_top_count) + array("bkl_facet" => $bkl_facet);
   }
   return json_encode($bkl_tree, JSON_UNESCAPED_UNICODE);
 }

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -184,6 +184,10 @@ function getBrowseTree() {
           $bkl_rest_cumsum += $bkl["count"];
         }
       }
+      $top_map_params = buildMaplink($GLOBALS['search_url'],
+                               array($bkl_top),
+                               "top",
+                               $bkl_top_count);
       $rest_map_params = buildMaplink($GLOBALS['search_url'],
                                $bkl_rest,
                                "bkl",
@@ -197,17 +201,17 @@ function getBrowseTree() {
       $bkl_tree[] = array("bkl_top_caption" => $bkl_top,
                           "count" => $bkl_top_count,
                           "bkl_facet" => $cleaned_bkl,
-                          "map_params" => $map_params);
+                          "map_params" => $top_map_params);
     }
     if ($bkl_top_count >= 10 and $bkl_top_count <= 100) {
-      $map_params = buildMaplink($GLOBALS['search_url'],
+      $top_map_params = buildMaplink($GLOBALS['search_url'],
                                array($bkl_top),
                                "top",
                                $bkl_top_count);
       $bkl_tree[] = array("bkl_top_caption" => $bkl_top,
                           "count" => $bkl_top_count,
                           "bkl_facet" => $bkl_facet,
-                          "map_params" => $map_params);
+                          "map_params" => $top_map_params);
     }
     if ($bkl_top_count < 10) {
       $bkl_top_rest[] = $bkl_top;

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -179,7 +179,7 @@ function loadOrRefresh($lc_cache) {
     try {
       $bkl_tree = getBrowseTree();
       # if no error occurred, update cache
-      #writeCache($lc_cache, $bkl_tree);
+      writeCache($lc_cache, $bkl_tree);
     }
     # if error in getting bkls occurs, catch error
     catch (exception $e) {

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -95,7 +95,7 @@ function getBklFacetData($base_url, $bkl_query, $bkls_top) {
             if ($bkl_counts[$i] > 0) {
               $res[$bkl_top][] = array("bkl_caption" => $bkl,
                                        "count" => $bkl_counts[$i],
-                                       "map_params" => "");
+                                       "map_params" => array());
             }
           }
         }

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -164,6 +164,8 @@ function getBrowseTree() {
                                    $bkls_top);
   # build tree
   $bkl_tree = array();
+  $bkl_top_rest = array();
+  $bkl_top_rest_cumsum = 0;
   foreach ($bkls_top as $i => $bkl_top) {
     $bkl_facet = $bkl_facetdata[$bkl_top];
     $bkl_top_count = $bkls_top_counts[$i];
@@ -209,7 +211,7 @@ function getBrowseTree() {
     }
     if ($bkl_top_count < 10) {
       $bkl_top_rest[] = $bkl_top;
-      $bkl_top_rest_cumsum = $bkl_top_count;
+      $bkl_top_rest_cumsum += $bkl_top_count;
     }
   }
   $rest_maplink = buildMaplink($GLOBALS['search_url'],

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -192,6 +192,9 @@ function getBrowseTree() {
       $bkl_facet[] = array("bkl_caption" => implode("; ", $bkl_rest),
                            "count" => $bkl_rest_cumsum,
                            "map_link" => "");
+      $bkl_facet = array_filter($bkl_facet, function ($bkl) {
+                                return ($bkl["count"] >= 10);
+                              });
       $bkl_tree[] = array("bkl_top_caption" => $bkl_top,
                           "count" => $bkl_top_count,
                           "bkl_facet" => $bkl_facet,
@@ -220,6 +223,9 @@ function getBrowseTree() {
                       "count" => $bkl_top_rest_cumsum,
                       "bkl_facet" => array(),
                       "map_link" => $rest_maplink);
+  $bkl_tree = array_filter($bkl_tree, function($bklt) {
+                           array($bklt["count"] >= 10);
+                           });
   return json_encode($bkl_tree, JSON_UNESCAPED_UNICODE);
 }
 

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -160,12 +160,12 @@ function getBrowseTree() {
                                    $bkls_top);
   # build tree
   $bkl_tree = array();
-  $bkl_top_rest = array();
-  $bkl_top_rest_cumsum = 0;
   foreach ($bkls_top as $i => $bkl_top) {
     $bkl_facet = $bkl_facetdata[$bkl_top];
     $bkl_top_count = $bkls_top_counts[$i];
-    $top_map_params = "";
+    $top_map_params = array();
+    $bkl_top_rest = array();
+    $bkl_top_rest_cumsum = 0;
     if ($bkl_top_count > 100) {
       $cleaned_bkl = array();
       $bkl_rest = array();
@@ -196,7 +196,7 @@ function getBrowseTree() {
                               });
       $bkl_tree[] = array("bkl_top_caption" => $bkl_top,
                           "count" => $bkl_top_count,
-                          "bkl_facet" => $bkl_facet,
+                          "bkl_facet" => $cleaned_bkl,
                           "map_params" => $map_params);
     }
     if ($bkl_top_count >= 10 and $bkl_top_count <= 100) {

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -1,9 +1,5 @@
 <?php
 
-# currently returns a list of lists:
-# [["(DE-588)11881835X","Pfizmaier, August",186,"1808-1887"],
-#  ["(DE-588)118545426","Hammer-Purgstall, Joseph <<von>>",83,"1774-1856"]]
-
 header('Content-type: application/json');
 
 require_once dirname(__FILE__) . '/../classes/headstart/library/CommUtils.php';
@@ -224,7 +220,7 @@ function getBrowseTree() {
                       "bkl_facet" => array(),
                       "map_params" => $rest_maplink);
   $bkl_tree = array_filter($bkl_tree, function($bklt) {
-                           array($bklt["count"] >= 10);
+                           return(array($bklt["count"] >= 10));
                            });
   return json_encode($bkl_tree, JSON_UNESCAPED_UNICODE);
 }

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -210,7 +210,7 @@ function getBrowseTree() {
                                $bkl_top_count);
       $bkl_tree[] = array("bkl_top_caption" => $bkl_top,
                           "count" => $bkl_top_count,
-                          "bkl_facet" => $bkl_facet,
+                          "bkl_facet" => array(),
                           "map_params" => $top_map_params);
     }
     if ($bkl_top_count < 10) {

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -99,7 +99,7 @@ function getBklFacetData($base_url, $bkl_query, $bkls_top) {
             if ($bkl_counts[$i] > 0) {
               $res[$bkl_top][] = array("bkl_caption" => $bkl,
                                        "count" => $bkl_counts[$i],
-                                       "map_link" => "");
+                                       "map_params" => "");
             }
           }
         }
@@ -169,46 +169,46 @@ function getBrowseTree() {
   foreach ($bkls_top as $i => $bkl_top) {
     $bkl_facet = $bkl_facetdata[$bkl_top];
     $bkl_top_count = $bkls_top_counts[$i];
-    $top_map_link = "";
+    $top_map_params = "";
     if ($bkl_top_count > 100) {
       $bkl_rest = array();
       $bkl_rest_cumsum = 0;
       foreach ($bkl_facet as $i => $bkl) {
         if ($bkl["count"] >= 10) {
-          $map_link = buildMaplink($GLOBALS['search_url'],
+          $map_params = buildMaplink($GLOBALS['search_url'],
                                    array($bkl["bkl_caption"]),
                                    "bkl",
                                    $bkl["count"]);
-          $bkl_facetdata[$bkl_top][$i]["map_link"] = $map_link ;
+          $bkl_facetdata[$bkl_top][$i]["map_params"] = $map_params ;
         } else {
           $bkl_rest[] = $bkl["bkl_caption"];
           $bkl_rest_cumsum += $bkl["count"];
         }
       }
-      $rest_map_link = buildMaplink($GLOBALS['search_url'],
+      $rest_map_params = buildMaplink($GLOBALS['search_url'],
                                $bkl_rest,
                                "bkl",
                                $bkl_rest_cumsum);
       $bkl_facet[] = array("bkl_caption" => implode("; ", $bkl_rest),
                            "count" => $bkl_rest_cumsum,
-                           "map_link" => "");
+                           "map_params" => "");
       $bkl_facet = array_filter($bkl_facet, function ($bkl) {
                                 return ($bkl["count"] >= 10);
                               });
       $bkl_tree[] = array("bkl_top_caption" => $bkl_top,
                           "count" => $bkl_top_count,
                           "bkl_facet" => $bkl_facet,
-                          "map_link" => $map_link);
+                          "map_params" => $map_params);
     }
     if ($bkl_top_count >= 10 and $bkl_top_count <= 100) {
-      $map_link = buildMaplink($GLOBALS['search_url'],
+      $map_params = buildMaplink($GLOBALS['search_url'],
                                array($bkl_top),
                                "top",
                                $bkl_top_count);
       $bkl_tree[] = array("bkl_top_caption" => $bkl_top,
                           "count" => $bkl_top_count,
                           "bkl_facet" => $bkl_facet,
-                          "map_link" => $map_link);
+                          "map_params" => $map_params);
     }
     if ($bkl_top_count < 10) {
       $bkl_top_rest[] = $bkl_top;
@@ -222,7 +222,7 @@ function getBrowseTree() {
   $bkl_tree[] = array("bkl_top_caption" => implode("; ", $bkl_top_rest),
                       "count" => $bkl_top_rest_cumsum,
                       "bkl_facet" => array(),
-                      "map_link" => $rest_maplink);
+                      "map_params" => $rest_maplink);
   $bkl_tree = array_filter($bkl_tree, function($bklt) {
                            array($bklt["count"] >= 10);
                            });

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -52,7 +52,6 @@ function getBklFacetData($base_url, $bkl_query, $bkls_top) {
   $window = 100;
   $res = array();
   $temp_res_bkl_top = array();
-  $temp_res_bkl_facets = array();
   $mh = curl_multi_init();
   $urls = array();
   foreach ($bkls_top as $i => $bkl_top) {
@@ -92,11 +91,11 @@ function getBklFacetData($base_url, $bkl_query, $bkls_top) {
               $bkl_counts[] = $v;
             }
           }
+          array_multisort($bkl_counts, SORT_DESC, $bkls);
+          $res[$bkl_top] = array();
           foreach ($bkls as $i => $bkl) {
             if ($bkl_counts[$i] > 0) {
-              $temp_res_bkl_facets[$bkl] = $bkl_counts[$i];
-              array_multisort($bkl_counts, SORT_DESC, $temp_res_bkl_facets);
-              $res[$bkl_top]["bkl_facet"] = $temp_res_bkl_facets;
+              $res[$bkl_top][] = array("bkl" => $bkl) + array("count" => $bkl_counts[$i]);
             }
           }
         }
@@ -142,19 +141,19 @@ function getBrowseTree() {
       $bkls_top_counts[] = $v;
     }
   }
-  # build tree
-  $bkl_tree = array();
+  array_multisort($bkls_top_counts, SORT_DESC, $bkls_top);
   # multicurl bkl_facet for top_bkls
   $bkl_facetdata = getBklFacetData($GLOBALS['base_url'],
                                    $GLOBALS['bkl_query'],
                                    $bkls_top);
   print_r($bkl_facetdata);
+  # build tree
+  $bkl_tree = array();
   foreach ($bkls_top as $i => $bkl_top) {
     $bkl_top_count = $bkls_top_counts[$i];
     $bkl_facet = $bkl_facetdata[$bkl_top]["bkl_facet"];
     $bkl_tree[] = array($bkl_top => $bkl_top_count) + array("bkl_facet" => $bkl_facet);
   }
-  array_multisort($bkls_top_counts, SORT_DESC, $bkl_tree);
   return json_encode($bkl_tree, JSON_UNESCAPED_UNICODE);
 }
 

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -137,9 +137,9 @@ function buildMaplink($search_url, $bkl_list, $bkl_level, $doc_count) {
                        'bkl_list' => $bkl_list,
                        'bkl_level' => $bkl_level,
                        'doc_count' => $doc_count);
-  $fields_string = http_build_query($post_fields);
-  $post_url = urlencode($search_url . "?" . $fields_string);
-  return $post_url;
+  // $fields_string = http_build_query($post_fields);
+  // $post_url = urlencode($search_url . "?" . $fields_string);
+  return $post_fields;
 }
 
 function getBrowseTree() {

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -160,12 +160,12 @@ function getBrowseTree() {
                                    $bkls_top);
   # build tree
   $bkl_tree = array();
+  $bkl_top_rest = array();
+  $bkl_top_rest_cumsum = 0;
   foreach ($bkls_top as $i => $bkl_top) {
     $bkl_facet = $bkl_facetdata[$bkl_top];
     $bkl_top_count = $bkls_top_counts[$i];
     $top_map_params = array();
-    $bkl_top_rest = array();
-    $bkl_top_rest_cumsum = 0;
     if ($bkl_top_count > 100) {
       $cleaned_bkl = array();
       $bkl_rest = array();
@@ -195,7 +195,7 @@ function getBrowseTree() {
       $cleaned_bkl[] = array("bkl_caption" => implode("; ", $bkl_rest),
                              "count" => $bkl_rest_cumsum,
                              "map_params" => $rest_map_params);
-      $bkl_facet = array_filter($bkl_facet, function ($bkl) {
+      $cleaned_bkl = array_filter($cleaned_bkl, function ($bkl) {
                                 return ($bkl["count"] >= 10);
                               });
       $bkl_tree[] = array("bkl_top_caption" => $bkl_top,

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -195,7 +195,7 @@ function getBrowseTree() {
       $bkl_tree[] = array("bkl_top_caption" => $bkl_top,
                           "count" => $bkl_top_count,
                           "bkl_facet" => $bkl_facet,
-                          "map_link" => $top_map_link);
+                          "map_link" => $rest_map_link);
     }
     if ($bkl_top_count >= 10 and $bkl_top_count <= 100) {
       $map_link = buildMaplink($GLOBALS['search_url'],
@@ -205,7 +205,7 @@ function getBrowseTree() {
       $bkl_tree[] = array("bkl_top_caption" => $bkl_top,
                           "count" => $bkl_top_count,
                           "bkl_facet" => $bkl_facet,
-                          "map_link" => $top_map_link);
+                          "map_link" => $map_link);
     }
     if ($bkl_top_count < 10) {
       $bkl_top_rest[] = $bkl_top;

--- a/server/services/searchLinkedCatBrowseview.php
+++ b/server/services/searchLinkedCatBrowseview.php
@@ -1,0 +1,24 @@
+<?php
+
+header('Content-type: application/json');
+
+require_once dirname(__FILE__) . '/../classes/headstart/library/CommUtils.php';
+require 'search.php';
+
+use headstart\library;
+
+$dirty_query = library\CommUtils::getParameter($_POST, "q");
+
+$post_params = $_POST;
+
+$result = search("linkedcat_browseview",
+                 $dirty_query,
+                 $post_params,
+                 array("today", "bkl_level", "bkl_list", "doc_count"),
+                 ";",
+                 null
+               );
+
+echo $result
+
+?>

--- a/server/services/searchLinkedCatBrowseview.php
+++ b/server/services/searchLinkedCatBrowseview.php
@@ -16,7 +16,8 @@ $result = search("linkedcat_browseview",
                  $post_params,
                  array("today", "bkl_level", "bkl_list", "doc_count"),
                  ";",
-                 null
+                 null,
+                 $transform_query_tolowercase = false
                );
 
 echo $result


### PR DESCRIPTION
This PR adds backend and service-layer functionality to
1) create a 2-layer tree of top and lower level document classification, their document counts, and search parameters to create maps
2) search for, and create maps given classification level, a list of classifications, and context parameters

The browseview-tree is cached for 24 hours.

* requires setting a new config parameter (linkedcat_browseview_cache) in config.ini: the location of lc_browseview_cache.json
* adds linkedcat_browseview.R, executing the SOLR search and retrieve
* adds test script and test params
* updates text_similarity.R interface
* adds getLinkedCatBrowseTree.php, which can be called to load from cache or create the browsetree
* adds a search service searchLinkedCatBrowseview.php, which calls the corresponding R service