### PR TITLE
added linkedcat_browseview to service-specific functions

### DIFF
--- a/server/preprocessing/other-scripts/preprocess.R
+++ b/server/preprocessing/other-scripts/preprocess.R
@@ -73,7 +73,7 @@ deduplicate_titles <- function(metadata, list_size) {
 
 replace_keywords_if_empty <- function(metadata, stops, service) {
   missing_subjects = which(lapply(metadata$subject, function(x) {nchar(x)}) <= 1)
-  if (service == "linkedcat" || service == "linkedcat_authorview") {
+  if (service == "linkedcat" || service == "linkedcat_authorview" || service == "linkedcat_browseview") {
     metadata$subject[missing_subjects] <- metadata$bkl_caption[missing_subjects]
     metadata$subject[is.na(metadata$subject)] <- ""
   } else {

--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -57,7 +57,7 @@ post_process <- function(sg_data) {
 
 sg_data = list()
 
-if (service == 'linkedcat' || service == 'linkedcat_authorview') {
+if (service == 'linkedcat' || service == 'linkedcat_authorview' || service == "linkedcat_browseview") {
   stream_range <- list(min=min(metadata$year), max=max(metadata$year), range=max(metadata$year)-min(metadata$year))
   metadata$boundary_label <- as.factor(metadata$year)
   levels(metadata$boundary_label) <- levels(as.factor(stream_range$min:stream_range$max))

--- a/server/preprocessing/other-scripts/summarize.R
+++ b/server/preprocessing/other-scripts/summarize.R
@@ -118,7 +118,7 @@ get_cluster_corpus <- function(clusters, metadata, service, stops, taxonomy_sepa
       subjects = lapply(subjects, function(x){paste(unlist(x), collapse=";")})
       subjects = mapply(paste, subjects, taxons, collapse=";")
     }
-    if (service == "linkedcat" || service == "linkedcat_authorview") {
+    if (service == "linkedcat" || service == "linkedcat_authorview" || service == "linkedcat_browseview") {
       all_subjects = paste(subjects, collapse=" ")
     } else {
       all_subjects = paste(subjects, title_ngrams$bigrams, title_ngrams$trigrams, collapse=" ")

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -71,7 +71,7 @@ get_service_lang <- function(lang_id, valid_langs, service) {
   } else {
     LANGUAGE <- 'english'
   }
-  if (service == 'linkedcat' || service == 'linkedcat_authorview') {
+  if (service == 'linkedcat' || service == 'linkedcat_authorview' || service == "linkedcat_browseview") {
       lang_id <- 'ger'
       LANGUAGE <- 'german'
     }


### PR DESCRIPTION
This PR fixes a browse-view issue where bubble titles like "Über das" appear. The problem is resolved by adding the browseview specific service to some preprocessing and summarization functions.
The difference can be observed on browseview-maps for Geowissenschaften Allgemeines and Rechtsgeschichte.