### PR TITLE
Linkedcat backend

### DIFF
--- a/server/preprocessing/other-scripts/postprocess.R
+++ b/server/preprocessing/other-scripts/postprocess.R
@@ -5,7 +5,6 @@ create_output <- function(named_clusters, layout, metadata) {
   x = layout$X1
   y = layout$X2
   labels = named_clusters$labels
-  groups = named_clusters$groups
   cluster = named_clusters$cluster
   num_clusters = named_clusters$num_clusters
   cluster_labels = named_clusters$cluster_labels

--- a/server/preprocessing/other-scripts/postprocess.R
+++ b/server/preprocessing/other-scripts/postprocess.R
@@ -11,7 +11,11 @@ create_output <- function(named_clusters, layout, metadata) {
   cluster_labels = named_clusters$cluster_labels
 
   # Prepare the output
-  result = cbind(x,y,groups,labels, cluster_labels)
+  unique_groups = data.frame(unique(result$cluster_labels))
+  colnames(unique_groups) <- "cluster_labels"
+  unique_groups$groups <- seq_along(unique_groups$cluster_labels)
+  result = data.frame(cbind(x, y, labels, cluster_labels))
+  result = merge(result, unique_groups, by='cluster_labels')
   output = merge(metadata, result, by.x="id", by.y="labels", all=TRUE)
 
   names(output)[names(output)=="groups"] <- "area_uri"

--- a/server/preprocessing/other-scripts/postprocess.R
+++ b/server/preprocessing/other-scripts/postprocess.R
@@ -11,10 +11,10 @@ create_output <- function(named_clusters, layout, metadata) {
   cluster_labels = named_clusters$cluster_labels
 
   # Prepare the output
+  result = data.frame(cbind(x, y, labels, cluster_labels))
   unique_groups = data.frame(unique(result$cluster_labels))
   colnames(unique_groups) <- "cluster_labels"
   unique_groups$groups <- seq_along(unique_groups$cluster_labels)
-  result = data.frame(cbind(x, y, labels, cluster_labels))
   result = merge(result, unique_groups, by='cluster_labels')
   output = merge(metadata, result, by.x="id", by.y="labels", all=TRUE)
 

--- a/server/preprocessing/other-scripts/postprocess.R
+++ b/server/preprocessing/other-scripts/postprocess.R
@@ -1,14 +1,14 @@
 vpplog <- getLogger('vis.postprocess')
 
-create_output <- function(clusters, layout, metadata) {
+create_output <- function(named_clusters, layout, metadata) {
 
   x = layout$X1
   y = layout$X2
-  labels = clusters$labels
-  groups = clusters$groups
-  cluster = clusters$cluster
-  num_clusters = clusters$num_clusters
-  cluster_labels = clusters$cluster_labels
+  labels = named_clusters$labels
+  groups = named_clusters$groups
+  cluster = named_clusters$cluster
+  num_clusters = named_clusters$num_clusters
+  cluster_labels = named_clusters$cluster_labels
 
   # Prepare the output
   result = cbind(x,y,groups,labels, cluster_labels)


### PR DESCRIPTION
This PR addresses the rare case two bubbles of documents are assigned the same bubble title by the naming component due to low availability of metadata; while the clustering component assigns the documents to two separate clusters.

* Bubble IDs handed over to the client are now assigned in a last step to guarantee that IDs correspond to unique bubble titles, ultimately derived from the naming component and not the clustering.

Differences can be seen on the author-map for Kenngott (Mineral bubble) and the browse-map for Biologie - Insecta (Insekten bubble)