### PR TITLE
Linkedcat search boost factors

### DIFF
--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -174,8 +174,15 @@ valid_langs <- list(
 )
 
 boost_factors <- list(
-  'ocrtext'=0.1,
-  'main_title'=2
+  'ocrtext'=0.01,
+  'main_title'=5,
+  'keyword_a'=3,
+  'keyword_c'=3,
+  'keyword_g'=3,
+  'keyword_t'=3,
+  'keyword_p'=3,
+  'keyword_x'=3,
+  'keyword_z'=3
 )
 
 build_authorfield_query <- function(field) {

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -130,8 +130,8 @@ build_query <- function(query, params, limit){
                 'tags', 'category', 'bib', 'language_code',
                 'ocrtext', 'goobi_link')
   query <- gsub(" ?<<von>>", "", query)
-  aq <- paste0(a_fields, ':', paste0(gsub("[^a-zA-Z<>]+", "*", query), "*"))
-  qq <- paste0(q_fields, ':', query)
+  aq <- paste0(lapply(q_fields, build_authorfield_query))
+  qq <- paste0(lapply(q_fields, build_queryfield_query))
   q <- paste(c(aq, qq), collapse = " OR ")
   q_params <- list(q = q, rows = limit, fl = r_fields)
 
@@ -173,3 +173,20 @@ build_query <- function(query, params, limit){
 valid_langs <- list(
     'ger'='german'
 )
+
+boost_factors <- list(
+  'ocrtext'=0.2,
+  'main_title'=1.5
+)
+
+build_authorfield_query <- function(field) {
+  paste0(field, ':', '"', paste0(gsub("[^a-zA-Z<>]+", "*", query), "*"), '"', add_boost_factor(field))
+}
+
+build_queryfield_query <- function(field) {
+  paste0(field, ':', '"', query, '"', add_boost_factor(field))
+}
+
+add_boost_factor <- function(field) {
+  if (field %in% names(boost_factors)) paste0('^', boost_factors[field]) else ""
+}

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -107,10 +107,9 @@ get_papers <- function(query, params, limit=100) {
 build_query <- function(query, params, limit){
   # fields to query in
   a_fields <- c('author100_a', 'author700_a')
-  q_fields <- c('main_title', 'ocrtext',
+  q_fields <- c('main_title', 'subtitle', 'ocrtext',
                 'author100_d', 'author100_0',
                 'author700_d', 'author700_0',
-                'main_title', 'subtitle',
                 'host_maintitle', 'host_pubplace',
                 'bkl_caption', 'bkl_top_caption',
                 'keyword_a', 'keyword_c', 'keyword_g', 'keyword_t',
@@ -175,8 +174,8 @@ valid_langs <- list(
 )
 
 boost_factors <- list(
-  'ocrtext'=0.2,
-  'main_title'=1.5
+  'ocrtext'=0.1,
+  'main_title'=2
 )
 
 build_authorfield_query <- function(field) {


### PR DESCRIPTION
This PR adds boosting/de-boosting to specific fields for the linkedcat-keyword search.

Boost factors for fields can be manipulated in the boost_factors list, if a field is not present its factor will not be modified. Currently the ocr-fulltext is very strongly deboosted, title strongly boosted and keyword fields slightly boosted.

Locally deployed tests show no changes when search phrase does not appear in title/keywords (e.g. hund/katze/maus);

Overview change when keywords indeed appear in title/keywords and a lot in fulltext, for example: wien, ägypten, sprache;