### PR TITLE
fix empty streamgraph labels

### DIFF
--- a/server/preprocessing/other-scripts/streamgraph.R
+++ b/server/preprocessing/other-scripts/streamgraph.R
@@ -77,6 +77,7 @@ if (service == 'linkedcat' || service == 'linkedcat_authorview' || service == "l
             %>% group_by(stream_item)
             %>% summarise(sum = sum(count))
             %>% arrange(desc(sum))
+            %>% mutate_if(is.character, list(~na_if(., "")))
             %>% drop_na()
             %>% head(12)
             %>% select(stream_item)


### PR DESCRIPTION
This PR fixes a bug where in rare cases invalid streamgraph data was created, with timeslices receiving a keyword count, but no associated label and no corresponding documents.
Empty metadata, should it appear, will now be replaced with "NA" and filtered out.

Test cases were "wien" and "Ettingshausen, Andreas" where the missing labels were fixed, and authors like Aschbach and Calasanza, where behavior is unchanged.