### PR TITLE
Linkedcat backend - config defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 server/preprocessing/other-scripts/.Rhistory
+server/preprocessing/other-scripts/renv
 /nbproject/private/
 /server/nbproject/private/
 *_local.*

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -40,7 +40,9 @@ get_papers <- function(query, params, limit=100) {
   start.time <- Sys.time()
   host=paste0(Sys.getenv("LINKEDCAT_USER"),":",Sys.getenv("LINKEDCAT_PWD"),"@",Sys.getenv("LINKEDCAT_SOLR"))
   conn <- SolrClient$new(host=host,
-                         path="solr/linkedcat2", port=NULL, scheme="https")
+                         path=Sys.getenv("LINKEDCAT_SOLR_PATH"),
+                         port=if (Sys.getenv("LINKEDCAT_SOLR_PORT")=="NULL") NULL else Sys.getenv("LINKEDCAT_SOLR_PORT"),
+                         scheme=Sys.getenv("LINKEDCAT_SOLR_SCHEME"))
 
   q_params <- build_query(query, params, limit)
   # do search

--- a/server/preprocessing/other-scripts/linkedcat_authorview.R
+++ b/server/preprocessing/other-scripts/linkedcat_authorview.R
@@ -40,7 +40,9 @@ get_papers <- function(query, params, limit=100) {
   start.time <- Sys.time()
   host=paste0(Sys.getenv("LINKEDCAT_USER"),":",Sys.getenv("LINKEDCAT_PWD"),"@",Sys.getenv("LINKEDCAT_SOLR"))
   conn <- SolrClient$new(host=host,
-                         path="solr/linkedcat2", port=NULL, scheme="https")
+                         path=Sys.getenv("LINKEDCAT_SOLR_PATH"),
+                         port=if (Sys.getenv("LINKEDCAT_SOLR_PORT")=="NULL") NULL else Sys.getenv("LINKEDCAT_SOLR_PORT"),
+                         scheme=Sys.getenv("LINKEDCAT_SOLR_SCHEME"))
 
   q_params <- build_query(query, params, limit)
   # do search

--- a/server/preprocessing/other-scripts/linkedcat_browseview.R
+++ b/server/preprocessing/other-scripts/linkedcat_browseview.R
@@ -40,7 +40,9 @@ get_papers <- function(query, params, limit=100) {
   start.time <- Sys.time()
   host=paste0(Sys.getenv("LINKEDCAT_USER"),":",Sys.getenv("LINKEDCAT_PWD"),"@",Sys.getenv("LINKEDCAT_SOLR"))
   conn <- SolrClient$new(host=host,
-                         path="solr/linkedcat2", port=NULL, scheme="https")
+                         path=Sys.getenv("LINKEDCAT_SOLR_PATH"),
+                         port=if (Sys.getenv("LINKEDCAT_SOLR_PORT")=="NULL") NULL else Sys.getenv("LINKEDCAT_SOLR_PORT"),
+                         scheme=Sys.getenv("LINKEDCAT_SOLR_SCHEME"))
 
   q_params <- build_query(query, params, limit)
   # do search

--- a/server/services/getLinkedCatAuthors.php
+++ b/server/services/getLinkedCatAuthors.php
@@ -63,6 +63,7 @@ function getAuthorData($base_url, $author_data_query, $author_ids) {
   $window = 100;
   $res = array();
   $mh = curl_multi_init();
+  curl_multi_setopt($mh, CURLMOPT_MAX_TOTAL_CONNECTIONS, 10);
   $urls = array();
   foreach ($author_ids as $i => $id) {
     if (strlen($id)>0) {
@@ -194,7 +195,7 @@ function loadOrRefresh($lc_cache) {
   # checks if file exists AND if its fresher than 24h
   # if true && true, load the cached file
   if (($GLOBALS['force_refresh'] == FALSE) &&
-       (file_exists($lc_cache) && (time() - filemtime($lc_cache) < 86400))
+       (file_exists($lc_cache) && (time() - filemtime($lc_cache) < 172800))
      ) {
     $authors = loadCache($lc_cache);
   }

--- a/server/services/getLinkedCatAuthors.php
+++ b/server/services/getLinkedCatAuthors.php
@@ -64,6 +64,7 @@ function getAuthorData($base_url, $author_data_query, $author_ids) {
   $res = array();
   $mh = curl_multi_init();
   curl_multi_setopt($mh, CURLMOPT_MAX_TOTAL_CONNECTIONS, 10);
+  curl_multi_setopt($mh, CURLMOPT_MAX_HOST_CONNECTIONS, 10);
   $urls = array();
   foreach ($author_ids as $i => $id) {
     if (strlen($id)>0) {

--- a/server/services/getLinkedCatAuthors.php
+++ b/server/services/getLinkedCatAuthors.php
@@ -17,7 +17,7 @@ $ini_array = library\Toolkit::loadIni($INI_DIR);
 $base_url = "https://" .
        $ini_array["connection"]["linkedcat_user"] . ":" .
        $ini_array["connection"]["linkedcat_pwd"] . "@" .
-       $ini_array["connection"]["linkedcat_solr"] . "/solr/linkedcat2/";
+       $ini_array["connection"]["linkedcat_solr"];
 
 $author_facet_query = "select?facet.field=author100_0" .
                       "&facet.field=author700_0" .

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -64,6 +64,7 @@ function getBklFacetData($base_url, $bkl_query, $bkls_top) {
   $temp_res_bkl_top = array();
   $mh = curl_multi_init();
   curl_multi_setopt($mh, CURLMOPT_MAX_TOTAL_CONNECTIONS, 10);
+  curl_multi_setopt($mh, CURLMOPT_MAX_HOST_CONNECTIONS, 10);
   $urls = array();
   foreach ($bkls_top as $i => $bkl_top) {
     if (strlen($bkl_top) > 0) {

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -63,6 +63,7 @@ function getBklFacetData($base_url, $bkl_query, $bkls_top) {
   $res = array();
   $temp_res_bkl_top = array();
   $mh = curl_multi_init();
+  curl_multi_setopt($mh, CURLMOPT_MAX_TOTAL_CONNECTIONS, 10);
   $urls = array();
   foreach ($bkls_top as $i => $bkl_top) {
     if (strlen($bkl_top) > 0) {
@@ -266,7 +267,7 @@ function loadOrRefresh($lc_cache) {
   # checks if file exists AND if its fresher than 24h
   # if true && true, load the cached file
   if (($GLOBALS['force_refresh'] == FALSE) &&
-       (file_exists($lc_cache) && (time() - filemtime($lc_cache) < 86400))
+       (file_exists($lc_cache) && (time() - filemtime($lc_cache) < 172800))
      ) {
     $bkl_tree = loadCache($lc_cache);
   }

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -13,7 +13,7 @@ $ini_array = library\Toolkit::loadIni($INI_DIR);
 $base_url = "https://" .
        $ini_array["connection"]["linkedcat_user"] . ":" .
        $ini_array["connection"]["linkedcat_pwd"] . "@" .
-       $ini_array["connection"]["linkedcat_solr"] . "/solr/linkedcat2/";
+       $ini_array["connection"]["linkedcat_solr"];
 
 $search_url = "services/searchLinkedCatBrowseview.php";
 


### PR DESCRIPTION
This PR addresses remaining deployment issues:

* A few hardcoded config files have been moved to environment variables. With this change, R now expects following environment variables either in Renviron.site or the System environment:
```
LINKEDCAT_SOLR = "url"
LINKEDCAT_SOLR_PATH = "solr/path"
LINKEDCAT_SOLR_PORT = "NULL" or port
LINKEDCAT_SOLR_SCHEME = "https" or "http"
```
Additionally, the `linkedcat_solr` setting in config_local.ini now has to point to the full path of the SOLR instance.

* Cache files for authors and the browse tree are now created with a rate limit, and the automatic refreshment has been bumped to 48h to give the cron job enough time.