### PR TITLE
Enable Boolean queries for BASE

### DIFF
--- a/examples/search_repos/data-config_base.js
+++ b/examples/search_repos/data-config_base.js
@@ -29,4 +29,6 @@ var data_config = {
     
     embed_modal: true,
     share_modal: false,
+    
+    show_keywords: true,
 };

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -39,9 +39,14 @@ get_papers <- function(query, params, limit=100,
   blog$info(paste("Search:", query))
   start.time <- Sys.time()
   
-  # remove unnecessary pluses and minuses
-  query_wt_plus = gsub("((^|\\s))[\\+]+[\\s]*", "\\1", query, perl=T)
-  query_cleaned = gsub("((^|\\s))[\\-]+[\\s]*", "\\1-", query_wt_plus, perl=T)
+  # remove pluses between terms
+  query_wt_plus = gsub("(?!\\B\"[^\"]*)[\\+]+(?![^\"]*\"\\B)", " ", query, perl=T)
+  # remove multiple minuses and spaces after minuses
+  query_wt_multi_minus = gsub("(?!\\B\"[^\"]*)((^|\\s))[\\-]+[\\s]*(?![^\"]*\"\\B)", "\\1-", query_wt_plus, perl=T)
+  # remove multiple spaces inside the query
+  query_wt_multi_spaces = gsub("(?!\\B\"[^\"]*)[\\s]{2,}(?![^\"]*\"\\B)", " ", query_wt_multi_minus, perl=T)
+  # trim query, if needed
+  query_cleaned = gsub("^\\s+|\\s+$", "", query_wt_multi_spaces, perl=T)
   
   # add "textus:" to each word/phrase to enable verbatim search
   # make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -45,7 +45,7 @@ get_papers <- function(query, params, limit=100,
   
   # add "textus:" to each word/phrase to enable verbatim search
   # make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"
-  exact_query = gsub('([\"]+(.*?)[\"]+)|(?<=\\(\\b|\\+|-\\"\\b)|(?!or\\b|and\\b|-[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
+  exact_query = gsub('([\"\']+(.*?)[\"\']+)|(?<=\\(\\b|\\+|-\\"\\b)|(?!or\\b|and\\b|-[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
                      , "textus:\\1", query_cleaned, perl=T)
   
   blog$info(paste("BASE query:", exact_query))

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -39,7 +39,7 @@ get_papers <- function(query, params, limit=100,
   blog$info(paste("Search:", query))
   start.time <- Sys.time()
   
-  # remove pluses between terms, remove spaces after minuses
+  # remove unnecessary pluses and minuses
   query_wt_plus = gsub("((^|\\s))[\\+]+[\\s]*", "\\1", query, perl=T)
   query_cleaned = gsub("((^|\\s))[\\-]+[\\s]*", "\\1-", query_wt_plus, perl=T)
   

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -41,8 +41,9 @@ get_papers <- function(query, params, limit=100,
 
   exact_query <- ""
 
-  # add textus: to each word/phrase to enable verbatim search
-  exact_query = gsub("(\"(.*?)\")|(?!or|and\\b)(?<!\\S)(?=\\S)", "textus:\\1", query, perl=T)
+  # add "textus:" to each word/phrase to enable verbatim search
+  # make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"
+  exact_query = gsub("(\"(.*?)\")|(?<=\\()|(?!or|and\\b)(?<!\\S)(?=\\S)(?!\\()", "textus:\\1", query, perl=T)
   
   blog$info(paste("BASE query:", exact_query))
 

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -45,7 +45,7 @@ get_papers <- function(query, params, limit=100,
   
   # add "textus:" to each word/phrase to enable verbatim search
   # make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"
-  exact_query = gsub('([\"\']+(.*?)[\"\']+)|(?<=\\(\\b|\\+|-\\"\\b)|(?!or\\b|and\\b|-[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
+  exact_query = gsub('([\"\']+(.*?)[\"\']+)|(?<=\\(\\b|\\+|-\\"\\b)|(?!or\\b|and\\b|[-]+[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
                      , "textus:\\1", query_cleaned, perl=T)
   
   blog$info(paste("BASE query:", exact_query))

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -45,7 +45,7 @@ get_papers <- function(query, params, limit=100,
   
   # add "textus:" to each word/phrase to enable verbatim search
   # make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"
-  exact_query = gsub('(\"(.*?)\")|(?<=\\(|\\+|-\\"\\b)|(?!or\\b|and\\b|-[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
+  exact_query = gsub('([\"]+(.*?)[\"]+)|(?<=\\(\\b|\\+|-\\"\\b)|(?!or\\b|and\\b|-[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
                      , "textus:\\1", query_cleaned, perl=T)
   
   blog$info(paste("BASE query:", exact_query))

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -43,7 +43,7 @@ get_papers <- function(query, params, limit=100,
 
   # add "textus:" to each word/phrase to enable verbatim search
   # make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"
-  exact_query = gsub("(\"(.*?)\")|(?<=\\()|(?!or|and\\b)(?<!\\S)(?=\\S)(?!\\()", "textus:\\1", query, perl=T)
+  exact_query = gsub("(\"(.*?)\")|(?<=\\()|(?<=-)|(?!or|and\\b)(?<!\\S)(?=\\S)(?!\\()(?!-)", "textus:\\1", query, perl=T)
   
   blog$info(paste("BASE query:", exact_query))
 

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -38,13 +38,15 @@ get_papers <- function(query, params, limit=100,
 
   blog$info(paste("Search:", query))
   start.time <- Sys.time()
-
-  exact_query <- ""
-
+  
+  # remove pluses between terms, remove spaces after minuses
+  query_wt_plus = gsub("(^|\\s)\\+[\\s]+", " ", query, perl=T)
+  query_cleaned = gsub("((^|\\s)-)[\\s]+", "\\1", query_wt_plus, perl=T)
+  
   # add "textus:" to each word/phrase to enable verbatim search
   # make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"
-  exact_query = gsub("(\"(.*?)\")|(?<=\\(|-|\\+)|(?!or|and\\b)(?<!\\S)(?=\\S)(?!\\(|-|\\+)"
-                     , "textus:\\1", query, perl=T)
+  exact_query = gsub('(\"(.*?)\")|(?<=\\(|\\+|-\\"\\b)|(?!or\\b|and\\b|-[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
+                     , "textus:\\1", query_cleaned, perl=T)
   
   blog$info(paste("BASE query:", exact_query))
 

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -43,7 +43,8 @@ get_papers <- function(query, params, limit=100,
 
   # add "textus:" to each word/phrase to enable verbatim search
   # make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"
-  exact_query = gsub("(\"(.*?)\")|(?<=\\()|(?<=-)|(?!or|and\\b)(?<!\\S)(?=\\S)(?!\\()(?!-)", "textus:\\1", query, perl=T)
+  exact_query = gsub("(\"(.*?)\")|(?<=\\(|-|\\+)|(?!or|and\\b)(?<!\\S)(?=\\S)(?!\\(|-|\\+)"
+                     , "textus:\\1", query, perl=T)
   
   blog$info(paste("BASE query:", exact_query))
 

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -40,12 +40,12 @@ get_papers <- function(query, params, limit=100,
   start.time <- Sys.time()
   
   # remove pluses between terms, remove spaces after minuses
-  query_wt_plus = gsub("(^|\\s)\\+[\\s]+", " ", query, perl=T)
-  query_cleaned = gsub("((^|\\s)-)[\\s]+", "\\1", query_wt_plus, perl=T)
+  query_wt_plus = gsub("((^|\\s))[\\+]+[\\s]*", "\\1", query, perl=T)
+  query_cleaned = gsub("((^|\\s))[\\-]+[\\s]*", "\\1-", query_wt_plus, perl=T)
   
   # add "textus:" to each word/phrase to enable verbatim search
   # make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"
-  exact_query = gsub('([\"\']+(.*?)[\"\']+)|(?<=\\(\\b|\\+|-\\"\\b)|(?!or\\b|and\\b|[-]+[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
+  exact_query = gsub('([\"\']+(.*?)[\"\']+)|(?<=\\(\\b|\\+|-\\"\\b|\\s-\\b|^-\\b)|(?!or\\b|and\\b|[-]+[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
                      , "textus:\\1", query_cleaned, perl=T)
   
   blog$info(paste("BASE query:", exact_query))

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -42,7 +42,7 @@ get_papers <- function(query, params, limit=100,
   exact_query <- ""
 
   # add textus: to each word/phrase to enable verbatim search
-  exact_query = exact_query = gsub("(\"(.*?)\")|(?!or\\b)(?!and\\b)(?<!\\S)(?=\\S)", "textus:\\1", query, perl=T)
+  exact_query = gsub("(\"(.*?)\")|(?!or|and\\b)(?<!\\S)(?=\\S)", "textus:\\1", query, perl=T)
   
   blog$info(paste("BASE query:", exact_query))
 

--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -42,7 +42,7 @@ get_papers <- function(query, params, limit=100,
   exact_query <- ""
 
   # add textus: to each word/phrase to enable verbatim search
-  exact_query = gsub("(\"(.*?)\")|(?<!\\S)(?=\\S)", "textus:\\1", query, perl=T)
+  exact_query = exact_query = gsub("(\"(.*?)\")|(?!or\\b)(?!and\\b)(?<!\\S)(?=\\S)", "textus:\\1", query, perl=T)
   
   blog$info(paste("BASE query:", exact_query))
 
@@ -64,9 +64,10 @@ get_papers <- function(query, params, limit=100,
   abstract_exists = "dcdescription:?"
   sortby_string = ifelse(params$sorting == "most-recent", "dcyear desc", "")
 
-  base_query <- paste(exact_query, lang_query, date_string, document_types, abstract_exists, collapse=" ")
+  base_query <- paste(paste0("(",exact_query,")") ,lang_query, date_string, document_types, abstract_exists, collapse=" ")
   
   blog$info(paste("Exact query:", base_query))
+  blog$info(paste("Sort by:", sortby_string))
   # execute search
   (res_raw <- bs_search(hits=limit
                         , query = base_query

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -7,7 +7,7 @@ options(warn=1)
 wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
 setwd(wd) #Don't forget to set your working directory
 
-query <- "education" #args[2]
+query <- "2019-ncov or sars-cov-2" #args[2]
 service <- "base"
 params <- NULL
 params_file <- "params_base.json"

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -7,7 +7,7 @@ options(warn=1)
 wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
 setwd(wd) #Don't forget to set your working directory
 
-query <- '"knowledge domain visualization" or ("knowledge map" and science)' #args[2]
+query <- '"knowledge discovery" -literature' #args[2]
 service <- "base"
 params <- NULL
 params_file <- "params_base.json"

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -7,7 +7,7 @@ options(warn=1)
 wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
 setwd(wd) #Don't forget to set your working directory
 
-query <- "2019-ncov or sars-cov-2" #args[2]
+query <- '"knowledge domain visualization" or ("knowledge map" and science)' #args[2]
 service <- "base"
 params <- NULL
 params_file <- "params_base.json"

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -7,7 +7,7 @@ options(warn=1)
 wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
 setwd(wd) #Don't forget to set your working directory
 
-query <- '"knowledge discovery" -literature' #args[2]
+query <- '2019-ncov or sars-cov-2' #args[2]
 service <- "base"
 params <- NULL
 params_file <- "params_base.json"

--- a/server/preprocessing/other-scripts/test/base_regex_test.R
+++ b/server/preprocessing/other-scripts/test/base_regex_test.R
@@ -8,33 +8,38 @@ queries = list('2019-ncov and sars-cov-2'='textus:2019-ncov and textus:sars-cov-
             ,'-2019-ncov'='-textus:2019-ncov'
             ,'--2019-ncov'='-textus:2019-ncov'
             ,'(a and b -"c")'='(textus:a and textus:b -textus:"c")'
-            ,'+-"'='textus:-"'
             ,'2019-ncov or sars-cov-2'='textus:2019-ncov or textus:sars-cov-2'
             ,'"2019-ncov" or "sars-cov-2"'='textus:"2019-ncov" or textus:"sars-cov-2"'
-            ,'"2019-ncov"+"sars-cov-2"'='textus:"2019-ncov"+textus:"sars-cov-2"'
+            ,'"2019-ncov"+"sars-cov-2"'='textus:"2019-ncov" textus:"sars-cov-2"'
             ,'"2019-ncov" + "sars-cov-2"'='textus:"2019-ncov" textus:"sars-cov-2"'
-            ,'"2019-ncov"+"sars-cov-2"'='textus:"2019-ncov"+textus:"sars-cov-2"'
+            ,'"2019-ncov"+"sars-cov-2"'='textus:"2019-ncov" textus:"sars-cov-2"'
             ,'(cats + dogs) or (sun - moon)'='(textus:cats textus:dogs) or (textus:sun -textus:moon)'
             ,'science -(research or knowledge or theory)'='textus:science -(textus:research or textus:knowledge or textus:theory)'
             ,'orandor or andorand'='textus:orandor or textus:andorand'
             ,'science -research -knowledge -theory'='textus:science -textus:research -textus:knowledge -textus:theory'
             ,'a+b'='textus:a textus:b'
             ,'and or not'='and or textus:not'
-            ,'-(dogs+cats)'='-(textus:dogs+textus:cats)'
+            ,'-(dogs+cats)'='-(textus:dogs textus:cats)'
             ,'((cats) and dogs)'='((textus:cats) and textus:dogs)'
-            ,'""knowledge and domain visualization""'='textus:""knowledge and domain visualization""'
+            ,'""knowledge -   and +domain visualization""'='textus:""knowledge -   and +domain visualization""'
             ,'((-""hello"") or test)'='((-textus:""hello"") or textus:test)'
             ,'cats - dogs'='textus:cats -textus:dogs'
             ,'cats --- dogs'='textus:cats -textus:dogs'
             ,'cats +++ dogs'='textus:cats textus:dogs'
             ,'\'\'test\'\''="textus:''test''"
-            ,'+++++++++++++++science'='textus:science')
+            ,'+++++++++++++++science'='textus:science'
+            ,'+a -b'='textus:a -textus:b')
 
 
 test_preprocess_query <- function(query) {
-  # remove pluses between terms, remove spaces after minuses
-  query_wt_plus = gsub("((^|\\s))[\\+]+[\\s]*", "\\1", query, perl=T)
-  query_cleaned = gsub("((^|\\s))[\\-]+[\\s]*", "\\1-", query_wt_plus, perl=T)
+  # remove pluses between terms
+  query_wt_plus = gsub("(?!\\B\"[^\"]*)[\\+]+(?![^\"]*\"\\B)", " ", query, perl=T)
+  # remove multiple minuses and spaces after minuses
+  query_wt_multi_minus = gsub("(?!\\B\"[^\"]*)((^|\\s))[\\-]+[\\s]*(?![^\"]*\"\\B)", "\\1-", query_wt_plus, perl=T)
+  # remove multiple spaces inside the query
+  query_wt_multi_spaces = gsub("(?!\\B\"[^\"]*)[\\s]{2,}(?![^\"]*\"\\B)", " ", query_wt_multi_minus, perl=T)
+  # trim query, if needed
+  query_cleaned = gsub("^\\s+|\\s+$", "", query_wt_multi_spaces, perl=T)
 
   # add "textus:" to each word/phrase to enable verbatim search
   # make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"

--- a/server/preprocessing/other-scripts/test/base_regex_test.R
+++ b/server/preprocessing/other-scripts/test/base_regex_test.R
@@ -27,15 +27,16 @@ query = c('2019-ncov and sars-cov-2'
             ,'cats --- dogs'
             ,'cats +++ dogs'
             ,'\'\'test\'\''
-            ,'a+b')
+            ,'a+b'
+            ,'+++++++++++++++science')
 
 # remove pluses between terms, remove spaces after minuses
-query_wt_plus = gsub("(^|\\s)[\\+]+[\\s]+", " ", query, perl=T)
-query_cleaned = gsub("((^|\\s)[-]+)[\\s]+", " \\1", query_wt_plus, perl=T)
+query_wt_plus = gsub("((^|\\s))[\\+]+[\\s]*", "\\1", query, perl=T)
+query_cleaned = gsub("((^|\\s))[\\-]+[\\s]*", "\\1-", query_wt_plus, perl=T)
 
 # add "textus:" to each word/phrase to enable verbatim search
 # make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"
-exact_query = gsub('([\"\']+(.*?)[\"\']+)|(?<=\\(\\b|\\+|-\\"\\b)|(?!or\\b|and\\b|[-]+[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
+exact_query = gsub('([\"\']+(.*?)[\"\']+)|(?<=\\(\\b|\\+|-\\"\\b|\\s-\\b|^-\\b)|(?!or\\b|and\\b|[-]+[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
                    , "textus:\\1", query_cleaned, perl=T)
 
 exact_query

--- a/server/preprocessing/other-scripts/test/base_regex_test.R
+++ b/server/preprocessing/other-scripts/test/base_regex_test.R
@@ -1,0 +1,41 @@
+query = c('2019-ncov and sars-cov-2'
+            ,'term1 term2 term3'
+            ,'(dog and cat) or (sun and moon)'
+            ,'cats and "mice and cheese"'
+            ,'cats or (sun and moon)'
+            ,'(parentheses or ("cats and dogs"))'
+            ,'-2019-ncov'
+            ,'--2019-ncov'
+            ,'(a and b -"c")'
+            ,'+-"'
+            ,'2019-ncov or sars-cov-2'
+            ,'"2019-ncov" or "sars-cov-2"'
+            ,'"2019-ncov"+"sars-cov-2"'
+            ,'"2019-ncov" + "sars-cov-2"'
+            ,'"2019-ncov"+"sars-cov-2"'
+            ,'(cats + dogs) or (sun - moon)'
+            ,'science -(research or knowledge or theory)'
+            ,'orandor or andorand'
+            ,'science -research -knowledge -theory'
+            ,'a+b'
+            ,'and or not'
+            ,'-(dogs+cats)'
+            ,'((cats) and dogs)'
+            ,'""knowledge and domain visualization""'
+            ,'((-""hello"") or test)'
+            ,'cats - dogs'
+            ,'cats --- dogs'
+            ,'cats +++ dogs'
+            ,'\'\'test\'\''
+            ,'a+b')
+
+# remove pluses between terms, remove spaces after minuses
+query_wt_plus = gsub("(^|\\s)[\\+]+[\\s]+", " ", query, perl=T)
+query_cleaned = gsub("((^|\\s)[-]+)[\\s]+", " \\1", query_wt_plus, perl=T)
+
+# add "textus:" to each word/phrase to enable verbatim search
+# make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"
+exact_query = gsub('([\"\']+(.*?)[\"\']+)|(?<=\\(\\b|\\+|-\\"\\b)|(?!or\\b|and\\b|[-]+[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
+                   , "textus:\\1", query_cleaned, perl=T)
+
+exact_query

--- a/server/preprocessing/other-scripts/test/base_regex_test.R
+++ b/server/preprocessing/other-scripts/test/base_regex_test.R
@@ -1,42 +1,51 @@
-query = c('2019-ncov and sars-cov-2'
-            ,'term1 term2 term3'
-            ,'(dog and cat) or (sun and moon)'
-            ,'cats and "mice and cheese"'
-            ,'cats or (sun and moon)'
-            ,'(parentheses or ("cats and dogs"))'
-            ,'-2019-ncov'
-            ,'--2019-ncov'
-            ,'(a and b -"c")'
-            ,'+-"'
-            ,'2019-ncov or sars-cov-2'
-            ,'"2019-ncov" or "sars-cov-2"'
-            ,'"2019-ncov"+"sars-cov-2"'
-            ,'"2019-ncov" + "sars-cov-2"'
-            ,'"2019-ncov"+"sars-cov-2"'
-            ,'(cats + dogs) or (sun - moon)'
-            ,'science -(research or knowledge or theory)'
-            ,'orandor or andorand'
-            ,'science -research -knowledge -theory'
-            ,'a+b'
-            ,'and or not'
-            ,'-(dogs+cats)'
-            ,'((cats) and dogs)'
-            ,'""knowledge and domain visualization""'
-            ,'((-""hello"") or test)'
-            ,'cats - dogs'
-            ,'cats --- dogs'
-            ,'cats +++ dogs'
-            ,'\'\'test\'\''
-            ,'a+b'
-            ,'+++++++++++++++science')
+# input - expected output
+queries = list('2019-ncov and sars-cov-2'='textus:2019-ncov and textus:sars-cov-2'
+            ,'term1 term2 term3'='textus:term1 textus:term2 textus:term3'
+            ,'(dog and cat) or (sun and moon)'='(textus:dog and textus:cat) or (textus:sun and textus:moon)'
+            ,'cats and "mice and cheese"'='textus:cats and textus:"mice and cheese"'
+            ,'cats or (sun and moon)'='textus:cats or (textus:sun and textus:moon)'
+            ,'(parentheses or ("cats and dogs"))'='(textus:parentheses or (textus:"cats and dogs"))'
+            ,'-2019-ncov'='-textus:2019-ncov'
+            ,'--2019-ncov'='-textus:2019-ncov'
+            ,'(a and b -"c")'='(textus:a and textus:b -textus:"c")'
+            ,'+-"'='textus:-"'
+            ,'2019-ncov or sars-cov-2'='textus:2019-ncov or textus:sars-cov-2'
+            ,'"2019-ncov" or "sars-cov-2"'='textus:"2019-ncov" or textus:"sars-cov-2"'
+            ,'"2019-ncov"+"sars-cov-2"'='textus:"2019-ncov"+textus:"sars-cov-2"'
+            ,'"2019-ncov" + "sars-cov-2"'='textus:"2019-ncov" textus:"sars-cov-2"'
+            ,'"2019-ncov"+"sars-cov-2"'='textus:"2019-ncov"+textus:"sars-cov-2"'
+            ,'(cats + dogs) or (sun - moon)'='(textus:cats textus:dogs) or (textus:sun -textus:moon)'
+            ,'science -(research or knowledge or theory)'='textus:science -(textus:research or textus:knowledge or textus:theory)'
+            ,'orandor or andorand'='textus:orandor or textus:andorand'
+            ,'science -research -knowledge -theory'='textus:science -textus:research -textus:knowledge -textus:theory'
+            ,'a+b'='textus:a textus:b'
+            ,'and or not'='and or textus:not'
+            ,'-(dogs+cats)'='-(textus:dogs+textus:cats)'
+            ,'((cats) and dogs)'='((textus:cats) and textus:dogs)'
+            ,'""knowledge and domain visualization""'='textus:""knowledge and domain visualization""'
+            ,'((-""hello"") or test)'='((-textus:""hello"") or textus:test)'
+            ,'cats - dogs'='textus:cats -textus:dogs'
+            ,'cats --- dogs'='textus:cats -textus:dogs'
+            ,'cats +++ dogs'='textus:cats textus:dogs'
+            ,'\'\'test\'\''="textus:''test''"
+            ,'+++++++++++++++science'='textus:science')
 
-# remove pluses between terms, remove spaces after minuses
-query_wt_plus = gsub("((^|\\s))[\\+]+[\\s]*", "\\1", query, perl=T)
-query_cleaned = gsub("((^|\\s))[\\-]+[\\s]*", "\\1-", query_wt_plus, perl=T)
 
-# add "textus:" to each word/phrase to enable verbatim search
-# make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"
-exact_query = gsub('([\"\']+(.*?)[\"\']+)|(?<=\\(\\b|\\+|-\\"\\b|\\s-\\b|^-\\b)|(?!or\\b|and\\b|[-]+[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
+test_preprocess_query <- function(query) {
+  # remove pluses between terms, remove spaces after minuses
+  query_wt_plus = gsub("((^|\\s))[\\+]+[\\s]*", "\\1", query, perl=T)
+  query_cleaned = gsub("((^|\\s))[\\-]+[\\s]*", "\\1-", query_wt_plus, perl=T)
+
+  # add "textus:" to each word/phrase to enable verbatim search
+  # make sure it is added after any opening parentheses to enable queries such as "(a and b) or (a and c)"
+  exact_query = gsub('([\"\']+(.*?)[\"\']+)|(?<=\\(\\b|\\+|-\\"\\b|\\s-\\b|^-\\b)|(?!or\\b|and\\b|[-]+[\\"\\(]*\\b)(?<!\\S)(?=\\S)(?!\\(|\\+)'
                    , "textus:\\1", query_cleaned, perl=T)
+  expected = queries[[query]]
+  if (exact_query != expected) {
+    print(paste("Processing fails for", query, ". Result:", exact_query, "Expected:", expected))
+  }
+}
 
-exact_query
+for (q in names(queries)) {
+  test_preprocess_query(q)
+}

--- a/server/preprocessing/other-scripts/test/params_base.json
+++ b/server/preprocessing/other-scripts/test/params_base.json
@@ -1,7 +1,7 @@
 {
   "document_types":["121"],
   "from":"1665-01-01",
-  "to":"2019-02-12",
+  "to":"2020-03-13",
   "sorting":"most-relevant",
   "lang_id":"eng"
 }


### PR DESCRIPTION
This PR enables all Boolean queries described in the [BASE Interface Guide](https://www.base-search.net/about/download/base_interface.pdf) (see section 4 on page 13) in verbatim mode. The changes have been extensively tested, but further tests would be very useful. Examples include:

* 2019-ncov or sars-cov-2
* (cats and dogs) or (sun and moon)
* research -science
* "knowledge domain visualization" or ("knowledge map" and (research or science))

