### PR TITLE
Linkedcat backend - Snapshots

### DIFF
--- a/examples/linkedcat/browse.php
+++ b/examples/linkedcat/browse.php
@@ -102,7 +102,7 @@ $date = new DateTime();
                                     + "&service_url=" + data_config.server_url + "services/searchLinkedCatBrowseview.php"
                                     + "&service_name=LinkedCat"
                                     + "&service=" + data_config.service
-                                    + "&visualization_mode=browse")
+                                    + "&vis_mode=browse")
                             )
                     win.post_data = {
                         q: build_q(map_params)

--- a/examples/linkedcat/building_map.php
+++ b/examples/linkedcat/building_map.php
@@ -73,8 +73,8 @@ if(!empty($_POST)) {
                                 + "&file=" + file
                                 + "&service=" + params.get("service")
                                 + "&service_name=" + service_name
-                                + "&visualization_mode=" + params.get("visualization_mode")
-                                + "&visualization_type=" + post_data.vis_type)
+                                + "&vis_mode=" + params.get("vis_mode")
+                                + "&vis_type=" + post_data.vis_type)
                         return false;
                     } else {
                         showErrorCreation();

--- a/examples/linkedcat/head_headstart.php
+++ b/examples/linkedcat/head_headstart.php
@@ -1,15 +1,15 @@
 <?php
     $meta_title = "";
     if($vis_type === "overview") {
-        if($mode === "keywords") {
+        if($vis_mode === "keywords") {
             $meta_title = "Knowledge Map für";
-        } else if ($mode === "authors") {
+        } else if ($vis_mode === "authors") {
             $meta_title = "Knowledge Map über die Werke von";
         }
     } else if($vis_type === "timeline") {
-        if($mode === "keywords") {
+        if($vis_mode === "keywords") {
             $meta_title = "Streamgraph für";
-        } else if ($mode === "authors") {
+        } else if ($vis_mode === "authors") {
             $meta_title = "Streamgraph über die Werke von";
         }
     }
@@ -23,7 +23,7 @@
             , "fb-image" => "$SNAPSHOT_PATH$id.png"
         );
 
-    include_once 'head_meta.php'; 
+    include_once 'head_meta.php';
 ?>
 
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
@@ -32,6 +32,6 @@
 <script src="https://code.jquery.com/jquery-3.4.1.min.js"integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
 <link type="text/css" rel="stylesheet" href="./css/menu.css">
 <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:600" rel="stylesheet"> 
+<link href="https://fonts.googleapis.com/css?family=Josefin+Sans:600" rel="stylesheet">
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
 <script type="text/javascript" src="./js/menu.js "></script>

--- a/examples/linkedcat/headstart.php
+++ b/examples/linkedcat/headstart.php
@@ -7,8 +7,8 @@ include 'config.php';
                 <?php 
                     $id = $_GET["file"];
                     $query = $_GET["query"];
-                    $vis_type = $_GET["visualization_type"];
-                    $mode = $_GET["visualization_mode"];
+                    $vis_type = $_GET["vis_type"];
+                    $vis_mode = $_GET["vis_mode"];
                     include('head_headstart.php') 
                 ?>
     </head>
@@ -71,24 +71,24 @@ include 'config.php';
         	}];
                 data_config.server_url = window.location.href.replace(/[^/]*$/, '') + "<?php echo $HEADSTART_PATH; ?>server/";
                 data_config.options = options_<?php echo $_GET['service'] ?>.dropdowns;
-                if(<?php echo json_encode($_GET['visualization_mode']) ?> === "authors") {
+                if(<?php echo json_encode($_GET['vis_mode']) ?> === "authors") {
                     data_config.is_authorview = true;
                 }   
-                if(<?php echo json_encode($_GET['visualization_type']) ?> === "timeline") {
+                if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
                     data_config.is_streamgraph = true;
                     //data_config.embed_modal = false;
                     data_config.show_area = false;
                     
-                    if(<?php echo json_encode($_GET['visualization_mode']) ?> === "authors") {
+                    if(<?php echo json_encode($_GET['vis_mode']) ?> === "authors") {
                         data_config.intro = intro_authors_timeline;
                     } else {
                         data_config.intro = intro_keywords_timeline;
                     }
                 } else {
-                    if (<?php echo json_encode($_GET['visualization_type']) ?> === "overview") {
-                        if(<?php echo json_encode($_GET['visualization_mode']) ?> === "authors") {
+                    if (<?php echo json_encode($_GET['vis_type']) ?> === "overview") {
+                        if(<?php echo json_encode($_GET['vis_mode']) ?> === "authors") {
                             data_config.intro = intro_authors_overview;
-                        } else if (<?php echo json_encode($_GET['visualization_mode']) ?> === "browse") {
+                        } else if (<?php echo json_encode($_GET['vis_mode']) ?> === "browse") {
                             data_config.intro = intro_browseview;
                         } else {
                             data_config.intro = intro_keywords_overview;

--- a/examples/linkedcat/index.php
+++ b/examples/linkedcat/index.php
@@ -29,7 +29,7 @@ include 'config.php';
         <script type ="text/javascript">
 
             let url = new URL(window.location.href);
-            let mode = url.searchParams.get("mode");
+            let mode = url.searchParams.get("vis_mode");
             if (mode === null) {
                 mode = "keywords";
             }

--- a/examples/linkedcat/js/search.js
+++ b/examples/linkedcat/js/search.js
@@ -1,7 +1,7 @@
 var service_url = data_config.server_url + "services/searchLinkedCat.php";
 var service_name = "LinkedCat";
 var options = options_linkedcat;
-var visualization_mode = "keywords"
+var vis_mode = "keywords"
 var author_id = "";
 var author_name = "";
 var author_count = 0;
@@ -13,7 +13,7 @@ var search_options;
 var chooseOptions = function () {
     search_options = SearchOptions;
 
-    switch (visualization_mode) {
+    switch (vis_mode) {
         case "keywords":
             options = options_linkedcat;
             service_url = data_config.server_url + "services/searchLinkedCat.php";
@@ -36,7 +36,7 @@ var chooseOptions = function () {
             options = options_linkedcat;
             service_url = data_config.server_url + "services/searchLinkedCat.php";
     }
-    
+
     search_options.init("#filter-container", options, has_options_link);
 
     options.dropdowns.forEach(function (entry) {
@@ -61,19 +61,19 @@ var chooseOptions = function () {
 
 var autocomplete_function;
 var autocomplete_interval;
- 
+
 var addAutoComplete = function() {
-    if(visualization_mode !== "authors") {
+    if(vis_mode !== "authors") {
         $("#searchfield").show();
-        $("#authors-loading").hide(); 
+        $("#authors-loading").hide();
     } else {
         if(autocomplete_data === null) {
             $("#searchfield").hide();
             $("#authors-loading").show();
         } else {
             $("#searchfield").show();
-            $("#authors-loading").hide(); 
-            
+            $("#authors-loading").hide();
+
             autocomplete_function = $('input[name="q"]').autoComplete({
                 minChars: 0,
                 cache: false,
@@ -82,7 +82,7 @@ var addAutoComplete = function() {
                     var choices = autocomplete_data;
                     var matches = [];
                     for (i=0; i<choices.length; i++) {
-                        if(typeof choices[i][1].toLowerCase === "undefined" 
+                        if(typeof choices[i][1].toLowerCase === "undefined"
                                 || choices[i][1].toLowerCase().indexOf === "undefined") {
                             continue;
                         }
@@ -121,7 +121,7 @@ var addAutoComplete = function() {
                     author_living_dates = item.data('living_dates');
                     author_image_link = item.data('image_link');
                     $("#searchform").validate().element('input[name=q]');
-                    
+
                     author_selected = true;
                     removeInputError();
                 }
@@ -137,8 +137,8 @@ function adaptInterface() {
 }
 
 function configureSearch() {
-    $("#searchform").attr("action", "building_map.php?" 
-                                        + encodeURI("&today=" + new Date().toLocaleDateString("en-US") 
+    $("#searchform").attr("action", "building_map.php?"
+                                        + encodeURI("&today=" + new Date().toLocaleDateString("en-US")
                                                         + "&author_id=" + author_id
                                                         + "&doc_count=" + author_count
                                                         + "&living_dates=" + author_living_dates
@@ -146,7 +146,7 @@ function configureSearch() {
                                                         + "&service_url=" + service_url
                                                         + "&service_name=" + service_name
                                                         + "&service=" + data_config.service
-                                                        + "&visualization_mode=" + visualization_mode
+                                                        + "&vis_mode=" + vis_mode
                                         )
                           );
 }
@@ -169,14 +169,14 @@ $("#searchform").submit(function (event) {
         showInputError("Bitte geben Sie ein Stichwort ein:");
         event.preventDefault();
     }
-    
-    if(visualization_mode === "authors" && !author_selected) {
+
+    if(vis_mode === "authors" && !author_selected) {
         showInputError("Bitte wählen Sie einen Autor aus der Liste aus:");
         event.preventDefault();
     }
-    
+
     configureSearch();
-    
+
     var ua = window.navigator.userAgent;
     var iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
     var webkit = !!ua.match(/WebKit/i);
@@ -193,13 +193,13 @@ $("#searchform").validate({
 });
 
 $(document).ready(function () {
-    
+
     var changeVisualization = function () {
-        visualization_mode = $("input[name='optradio']:checked").val();
-        
+        vis_mode = $("input[name='optradio']:checked").val();
+
         let url = new URL(window.location.href);
-        url.searchParams.delete("mode");
-        url.searchParams.append("mode", visualization_mode);
+        url.searchParams.delete("vis_mode");
+        url.searchParams.append("vis_mode", vis_mode);
         window.history.pushState({path:url.toString()}, '', url.toString());
 
         search_options.user_defined_date = false;
@@ -207,26 +207,26 @@ $(document).ready(function () {
         $("#filter-container").html("");
         $('.author-btn').removeClass('btn-enabled');
         $('.keyword-btn').removeClass('btn-enabled');
-        
+
         if (typeof autocomplete_function === "object" && autocomplete_function !== null) {
             $('input[name="q"]').autoComplete('destroy');
             autocomplete_function = null;
         }
-        
+
         removeInputError();
         chooseOptions();
         adaptInterface();
         configureSearch();
         addAutoComplete();
     };
-    
+
     $("input[name='optradio']").change(changeVisualization);
 
     chooseOptions();
     configureSearch();
     addAutoComplete();
-    
+
     changeVisualization();
-    
+
      $('[data-toggle="popover"]').popover();
 });

--- a/server/classes/headstart/preprocessing/Snapshot.php
+++ b/server/classes/headstart/preprocessing/Snapshot.php
@@ -5,13 +5,16 @@ namespace headstart\preprocessing;
 class Snapshot
 {
     protected $cmd;
-    public function __construct($ini_array, $query, $id, $service, $service_name) {
+    public function __construct($ini_array, $query, $id, $service, $service_name, $vis_type) {
         $post_data = array(
             "query" => $query,
             "file" => $id,
             "service_name" => $service_name,
             "service" => $service
         );
+        if ($service_name == "LinkedCat") {
+          $post_data["vis_type"] = $vis_type;
+          }
         $url_postfix = http_build_query($post_data);
 
         $node_path = $ini_array["snapshot"]["node_path"];

--- a/server/classes/headstart/preprocessing/Snapshot.php
+++ b/server/classes/headstart/preprocessing/Snapshot.php
@@ -14,12 +14,17 @@ class Snapshot
         );
         if ($service_name == "LinkedCat") {
           $post_data["vis_type"] = $vis_type;
+          $post_data["service_name"] = "linkedcat";
           }
         if ($service == "linkedcat_authorview") {
           $post_data["vis_mode"] = "authors";
+          $post_data["service"] = "linkedcat";
+          $post_data["service_name"] = "linkedcat";
         }
         if ($service == "linkedcat_browseview") {
           $post_data["vis_mode"] = "browse";
+          $post_data["service"] = "linkedcat";
+          $post_data["service_name"] = "linkedcat";
         }
         $url_postfix = http_build_query($post_data);
 

--- a/server/classes/headstart/preprocessing/Snapshot.php
+++ b/server/classes/headstart/preprocessing/Snapshot.php
@@ -15,6 +15,12 @@ class Snapshot
         if ($service_name == "LinkedCat") {
           $post_data["vis_type"] = $vis_type;
           }
+        if ($service == "linkedcat_authorview") {
+          $post_data["vis_mode"] = "authors";
+        }
+        if ($service == "linkedcat_browseview") {
+          $post_data["vis_mode"] = "browse";
+        }
         $url_postfix = http_build_query($post_data);
 
         $node_path = $ini_array["snapshot"]["node_path"];

--- a/server/services/getLinkedCatAuthors.php
+++ b/server/services/getLinkedCatAuthors.php
@@ -14,7 +14,13 @@ use headstart\library;
 $INI_DIR = dirname(__FILE__) . "/../preprocessing/conf/";
 $ini_array = library\Toolkit::loadIni($INI_DIR);
 
-$base_url = "https://" .
+if (isset($ini_array["connection"]["linkedcat_protocol"])) {
+  $lc_protocol = $ini_array["connection"]["linkedcat_protocol"];
+} else {
+  $lc_protocol = "https";
+}
+
+$base_url = $lc_protocol . "://" .
        $ini_array["connection"]["linkedcat_user"] . ":" .
        $ini_array["connection"]["linkedcat_pwd"] . "@" .
        $ini_array["connection"]["linkedcat_solr"];

--- a/server/services/getLinkedCatBrowseTree.php
+++ b/server/services/getLinkedCatBrowseTree.php
@@ -10,7 +10,13 @@ use headstart\library;
 $INI_DIR = dirname(__FILE__) . "/../preprocessing/conf/";
 $ini_array = library\Toolkit::loadIni($INI_DIR);
 
-$base_url = "https://" .
+if (isset($ini_array["connection"]["linkedcat_protocol"])) {
+  $lc_protocol = $ini_array["connection"]["linkedcat_protocol"];
+} else {
+  $lc_protocol = "https";
+}
+
+$base_url = $lc_protocol . "://" .
        $ini_array["connection"]["linkedcat_user"] . ":" .
        $ini_array["connection"]["linkedcat_pwd"] . "@" .
        $ini_array["connection"]["linkedcat_solr"];

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -115,7 +115,12 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
                             , "linkedcat" => "LinkedCat");
 
     if(!isset($ini_array["snapshot"]["snapshot_enabled"]) || $ini_array["snapshot"]["snapshot_enabled"] > 0) {
-        $snapshot = new \headstart\preprocessing\Snapshot($ini_array, $query, $unique_id, $repository, $repo_mapping[$repository]);
+        if ($post_params["vis_type"] == "overview") {
+          $vis_type = "overview";
+        } else {
+          $vis_type = "timeline";
+        }
+        $snapshot = new \headstart\preprocessing\Snapshot($ini_array, $query, $unique_id, $repository, $repo_mapping[$repository], $vis_type);
         $snapshot->takeSnapshot();
     }
 

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -112,13 +112,15 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
                             , "doaj" => "DOAJ"
                             , "base" => "BASE"
                             , "openaire" => "OpenAire"
-                            , "linkedcat" => "LinkedCat");
+                            , "linkedcat" => "LinkedCat"
+                            , "linkedcat_authorview" => "LinkedCat"
+                            , "linkedcat_browseview" => "LinkedCat");
 
     if(!isset($ini_array["snapshot"]["snapshot_enabled"]) || $ini_array["snapshot"]["snapshot_enabled"] > 0) {
-        if ($post_params["vis_type"] == "overview") {
-          $vis_type = "overview";
-        } else {
+        if ($post_params["vis_type"] == "timeline") {
           $vis_type = "timeline";
+        } else {
+          $vis_type = "overview";
         }
         $snapshot = new \headstart\preprocessing\Snapshot($ini_array, $query, $unique_id, $repository, $repo_mapping[$repository], $vis_type);
         $snapshot->takeSnapshot();

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -117,10 +117,15 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
                             , "linkedcat_browseview" => "LinkedCat");
 
     if(!isset($ini_array["snapshot"]["snapshot_enabled"]) || $ini_array["snapshot"]["snapshot_enabled"] > 0) {
-        if ($post_params["vis_type"] == "timeline") {
-          $vis_type = "timeline";
-        } else {
-          $vis_type = "overview";
+        if ($repository == "linkedcat" || $repository == "linkedcat_authorview" || $repository == "linkedcat_browseview") {
+          if ($post_params["vis_type"] == "timeline") {
+            $vis_type = "timeline";
+          } else {
+            $vis_type = "overview";
+          }
+        }
+        else {
+          $vis_type = NULL;
         }
         $snapshot = new \headstart\preprocessing\Snapshot($ini_array, $query, $unique_id, $repository, $repo_mapping[$repository], $vis_type);
         $snapshot->takeSnapshot();

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -117,15 +117,10 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
                             , "linkedcat_browseview" => "LinkedCat");
 
     if(!isset($ini_array["snapshot"]["snapshot_enabled"]) || $ini_array["snapshot"]["snapshot_enabled"] > 0) {
-        if ($repository == "linkedcat" || $repository == "linkedcat_authorview" || $repository == "linkedcat_browseview") {
-          if ($post_params["vis_type"] == "timeline") {
-            $vis_type = "timeline";
-          } else {
-            $vis_type = "overview";
-          }
-        }
-        else {
-          $vis_type = NULL;
+        if (isset($post_params["vis_type"]) && $post_params["vis_type"] == "timeline") {
+          $vis_type = "timeline";
+        } else {
+          $vis_type = "overview";
         }
         $snapshot = new \headstart\preprocessing\Snapshot($ini_array, $query, $unique_id, $repository, $repo_mapping[$repository], $vis_type);
         $snapshot->takeSnapshot();

--- a/server/services/snapshot/data-config_linkedcat.js
+++ b/server/services/snapshot/data-config_linkedcat.js
@@ -1,0 +1,45 @@
+var data_config = {
+    tag: "visualization",
+    mode: "search_repos",
+
+    service: "linkedcat",
+
+    title: "",
+    base_unit: "citations",
+    use_area_uri: true,
+    show_multiples: false,
+    show_dropdown: false,
+    show_infolink: true,
+    preview_type: "pdf",
+    sort_options: ["relevance", "title", "authors", "year"],
+    is_force_areas: true,
+    language: "ger_linkedcat",
+    hyphenation_language: "de",
+    area_force_alpha: 0.025,
+    show_list: true,
+    content_based: true,
+    url_prefix: "https://permalink.obvsg.at/",
+    show_keywords: true,
+    hide_keywords_overview: false,
+    convert_author_names: false,
+
+    show_context: true,
+    create_title_from_context: true,
+    create_title_from_context_style: "linkedcat",
+
+    embed_modal: true,
+    share_modal: true,
+
+    url_outlink: true,
+    filter_menu_dropdown: false,
+    sort_menu_dropdown: true,
+    //filter_options: ["all", "open_access"],
+
+    show_context_oa_number: false,
+    abstract_large: 1000,
+
+    streamgraph_zoom: false,
+    canonical_url: "https://openknowledgemaps.org",
+
+    hashtags_twitter_card: "",
+};

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -17,27 +17,28 @@
             data_config.show_context = true;
             data_config.create_title_from_context= true;
             data_config.options = options_<?php echo $_GET['service']; ?>.dropdowns;
-            if (<?php echo json_encode($_GET['service']) ?> === "linkedcat" ||
-                <?php echo json_encode($_GET['service']) ?> === "linkedcat_authorview" ||
-                <?php echo json_encode($_GET['service']) ?> === "linkedcat_browseview") {
-                if(<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "authors") {
+            var service = <?php echo isset($_GET['service']) ? json_encode($_GET['service']) : NULL ?>;
+            var vis_type = <?php echo isset($_GET['vis_type']) ? json_encode($_GET['vis_type']) : NULL ?>;
+            var vis_mode = <?php echo isset($_GET['vis_mode']) ? json_encode($_GET['vis_mode']) : NULL ?>;
+            if ( ["linkedcat", "linkedcat_authorview", "linkedcat_browseview"].some(service) ) {
+                if( vis_mode === "authors") {
                     data_config.is_authorview = true;
                 }
-                if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
+                if( vis_type === "timeline") {
                     data_config.is_streamgraph = true;
                     //data_config.embed_modal = false;
                     data_config.show_area = false;
 
-                    if(<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "authors") {
+                    if( vis_mode === "authors") {
                         data_config.intro = "";
                     } else {
                         data_config.intro = "";
                     }
                 } else {
-                    if (<?php echo json_encode($_GET['vis_type']) ?> === "overview") {
-                        if(<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "authors") {
+                    if (vis_type === "overview") {
+                        if(vis_mode === "authors") {
                             data_config.intro = "";
-                        } else if (<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "browse") {
+                        } else if (vis_mode === "browse") {
                             data_config.intro = "";
                         } else {
                             data_config.intro = "";

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -29,18 +29,18 @@
                     data_config.show_area = false;
 
                     if(<?php echo json_encode($_GET['vis_mode']) ?> === "authors") {
-                        data_config.intro = intro_authors_timeline;
+                        data_config.intro = "";
                     } else {
-                        data_config.intro = intro_keywords_timeline;
+                        data_config.intro = "";
                     }
                 } else {
                     if (<?php echo json_encode($_GET['vis_type']) ?> === "overview") {
                         if(<?php echo json_encode($_GET['vis_mode']) ?> === "authors") {
-                            data_config.intro = intro_authors_overview;
+                            data_config.intro = "";
                         } else if (<?php echo json_encode($_GET['vis_mode']) ?> === "browse") {
-                            data_config.intro = intro_browseview;
+                            data_config.intro = "";
                         } else {
-                            data_config.intro = intro_keywords_overview;
+                            data_config.intro = "";
                         }
                     }
                 }

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -4,7 +4,7 @@
     </head>
 
     <body style="margin:0px; padding:0px">
-        
+
         <div id="visualization"></div>
         <script type="text/javascript" src="data-config_<?php echo $_GET['service'] ?>.js"></script>
 		<script src="../../../../js/search_options.js"></script>
@@ -17,7 +17,7 @@
             data_config.show_context = true;
             data_config.create_title_from_context= true;
             data_config.options = options_<?php echo $_GET['service']; ?>.dropdowns;
-            if(<?php echo json_encode($_GET['visualization_type']) ?> === "timeline") {
+            if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
                 data_config.is_streamgraph = true;
                 //data_config.embed_modal = false;
                 data_config.show_area = false;

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -20,7 +20,7 @@
             if (<?php echo json_encode($_GET['service']) ?> === "linkedcat" ||
                 <?php echo json_encode($_GET['service']) ?> === "linkedcat_authorview" ||
                 <?php echo json_encode($_GET['service']) ?> === "linkedcat_browseview") {
-                if(<?php echo json_encode($_GET['vis_mode']) ?> === "authors") {
+                if(<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "authors") {
                     data_config.is_authorview = true;
                 }
                 if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
@@ -28,16 +28,16 @@
                     //data_config.embed_modal = false;
                     data_config.show_area = false;
 
-                    if(<?php echo json_encode($_GET['vis_mode']) ?> === "authors") {
+                    if(<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "authors") {
                         data_config.intro = "";
                     } else {
                         data_config.intro = "";
                     }
                 } else {
                     if (<?php echo json_encode($_GET['vis_type']) ?> === "overview") {
-                        if(<?php echo json_encode($_GET['vis_mode']) ?> === "authors") {
+                        if(<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "authors") {
                             data_config.intro = "";
-                        } else if (<?php echo json_encode($_GET['vis_mode']) ?> === "browse") {
+                        } else if (<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "browse") {
                             data_config.intro = "";
                         } else {
                             data_config.intro = "";

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -20,24 +20,24 @@
             if (<?php echo json_encode($_GET['service']) ?> === "linkedcat" ||
                 <?php echo json_encode($_GET['service']) ?> === "linkedcat_authorview" ||
                 <?php echo json_encode($_GET['service']) ?> === "linkedcat_browseview") {
-                if(<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "authors") {
+                if(<?php echo json_encode(isset($_GET['vis_mode']) ? $_GET['vis_mode'] : "") ?> === "authors") {
                     data_config.is_authorview = true;
                 }
-                if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
+                if(<?php echo json_encode(isset($_GET['vis_type']) ? $_GET['vis_type'] : "") ?> === "timeline") {
                     data_config.is_streamgraph = true;
                     //data_config.embed_modal = false;
                     data_config.show_area = false;
 
-                    if(<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "authors") {
+                    if(<?php echo json_encode(isset($_GET['vis_mode']) ? $_GET['vis_mode'] : "") ?> === "authors") {
                         data_config.intro = "";
                     } else {
                         data_config.intro = "";
                     }
                 } else {
-                    if (<?php echo json_encode($_GET['vis_type']) ?> === "overview") {
-                        if(<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "authors") {
+                    if (<?php echo json_encode(isset($_GET['vis_type']) ? $_GET['vis_type'] : "") ?> === "overview") {
+                        if(<?php echo json_encode(isset($_GET['vis_mode']) ? $_GET['vis_mode'] : "") ?> === "authors") {
                             data_config.intro = "";
-                        } else if (<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "browse") {
+                        } else if (<?php echo json_encode(isset($_GET['vis_mode']) ? $_GET['vis_mode'] : "") ?> === "browse") {
                             data_config.intro = "";
                         } else {
                             data_config.intro = "";

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -17,6 +17,11 @@
             data_config.show_context = true;
             data_config.create_title_from_context= true;
             data_config.options = options_<?php echo $_GET['service']; ?>.dropdowns;
+            if(<?php echo json_encode($_GET['visualization_type']) ?> === "timeline") {
+                data_config.is_streamgraph = true;
+                //data_config.embed_modal = false;
+                data_config.show_area = false;
+            }
         </script>
         <script type="text/javascript" src="../../../dist/headstart.js"></script>
         <link type="text/css" rel="stylesheet" href="../../../dist/headstart.css"></link>

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -17,7 +17,9 @@
             data_config.show_context = true;
             data_config.create_title_from_context= true;
             data_config.options = options_<?php echo $_GET['service']; ?>.dropdowns;
-            if (<?php echo json_encode($_GET['service']) ?>.some(["linkedcat", "linkedcat_authorview", "linkedcat_browseview"])) {
+            if (<?php echo json_encode($_GET['service']) ?> === "linkedcat" ||
+                <?php echo json_encode($_GET['service']) ?> === "linkedcat_authorview" ||
+                <?php echo json_encode($_GET['service']) ?> === "linkedcat_browseview") {
               if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
                   data_config.is_streamgraph = true;
                   //data_config.embed_modal = false;

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -20,7 +20,7 @@
             var service = <?php echo isset($_GET['service']) ? json_encode($_GET['service']) : NULL ?>;
             var vis_type = <?php echo isset($_GET['vis_type']) ? json_encode($_GET['vis_type']) : NULL ?>;
             var vis_mode = <?php echo isset($_GET['vis_mode']) ? json_encode($_GET['vis_mode']) : NULL ?>;
-            if ( ["linkedcat", "linkedcat_authorview", "linkedcat_browseview"].some(service) ) {
+            if ( ["linkedcat", "linkedcat_authorview", "linkedcat_browseview"].includes(service) ) {
                 if( vis_mode === "authors") {
                     data_config.is_authorview = true;
                 }

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -17,7 +17,7 @@
             data_config.show_context = true;
             data_config.create_title_from_context= true;
             data_config.options = options_<?php echo $_GET['service']; ?>.dropdowns;
-            if <?php echo json_encode($_GET['service']) ?>.some(["linkedcat", "linkedcat_authorview", "linkedcat_browseview"]) {
+            if (<?php echo json_encode($_GET['service']) ?>.some(["linkedcat", "linkedcat_authorview", "linkedcat_browseview"])) {
               if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
                   data_config.is_streamgraph = true;
                   //data_config.embed_modal = false;

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -17,10 +17,12 @@
             data_config.show_context = true;
             data_config.create_title_from_context= true;
             data_config.options = options_<?php echo $_GET['service']; ?>.dropdowns;
-            if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
-                data_config.is_streamgraph = true;
-                //data_config.embed_modal = false;
-                data_config.show_area = false;
+            if <?php echo json_encode($_GET['service']) ?>.some(["linkedcat", "linkedcat_authorview", "linkedcat_browseview"]) {
+              if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
+                  data_config.is_streamgraph = true;
+                  //data_config.embed_modal = false;
+                  data_config.show_area = false;
+              }
             }
         </script>
         <script type="text/javascript" src="../../../dist/headstart.js"></script>

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -17,10 +17,11 @@
             data_config.show_context = true;
             data_config.create_title_from_context= true;
             data_config.options = options_<?php echo $_GET['service']; ?>.dropdowns;
-            var service = <?php echo isset($_GET['service']) ? json_encode($_GET['service']) : NULL ?>;
-            var vis_type = <?php echo isset($_GET['vis_type']) ? json_encode($_GET['vis_type']) : NULL ?>;
-            var vis_mode = <?php echo isset($_GET['vis_mode']) ? json_encode($_GET['vis_mode']) : NULL ?>;
-            if ( ["linkedcat", "linkedcat_authorview", "linkedcat_browseview"].includes(service) ) {
+            var service = <?php echo (isset($_GET['service']) ? json_encode($_GET['service']) : json_encode("")) ?>;
+            var vis_type = <?php echo (isset($_GET['vis_type']) ? json_encode($_GET['vis_type']) : json_encode("")) ?>;
+            var vis_mode = <?php echo (isset($_GET['vis_mode']) ? json_encode($_GET['vis_mode']) : json_encode("")) ?>;
+            var special_services = ["linkedcat", "linkedcat_authorview", "linkedcat_browseview"];
+            if ( special_services.includes(service) ) {
                 if( vis_mode === "authors") {
                     data_config.is_authorview = true;
                 }

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -20,11 +20,30 @@
             if (<?php echo json_encode($_GET['service']) ?> === "linkedcat" ||
                 <?php echo json_encode($_GET['service']) ?> === "linkedcat_authorview" ||
                 <?php echo json_encode($_GET['service']) ?> === "linkedcat_browseview") {
-              if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
-                  data_config.is_streamgraph = true;
-                  //data_config.embed_modal = false;
-                  data_config.show_area = false;
-              }
+                if(<?php echo json_encode($_GET['vis_mode']) ?> === "authors") {
+                    data_config.is_authorview = true;
+                }
+                if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
+                    data_config.is_streamgraph = true;
+                    //data_config.embed_modal = false;
+                    data_config.show_area = false;
+
+                    if(<?php echo json_encode($_GET['vis_mode']) ?> === "authors") {
+                        data_config.intro = intro_authors_timeline;
+                    } else {
+                        data_config.intro = intro_keywords_timeline;
+                    }
+                } else {
+                    if (<?php echo json_encode($_GET['vis_type']) ?> === "overview") {
+                        if(<?php echo json_encode($_GET['vis_mode']) ?> === "authors") {
+                            data_config.intro = intro_authors_overview;
+                        } else if (<?php echo json_encode($_GET['vis_mode']) ?> === "browse") {
+                            data_config.intro = intro_browseview;
+                        } else {
+                            data_config.intro = intro_keywords_overview;
+                        }
+                    }
+                }
             }
         </script>
         <script type="text/javascript" src="../../../dist/headstart.js"></script>

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -17,29 +17,27 @@
             data_config.show_context = true;
             data_config.create_title_from_context= true;
             data_config.options = options_<?php echo $_GET['service']; ?>.dropdowns;
-            var service = <?php echo $_GET['service']; ?>;
-            var special_services = ["linkedcat", "linkedcat_authorview", "linkedcat_browseview"];
-            if ( special_services.includes(service) ) {
-                var vis_type = <?php echo (isset($_GET['vis_type']) ? json_encode($_GET['vis_type']) : json_encode("")); ?>;
-                var vis_mode = <?php echo (isset($_GET['vis_mode']) ? json_encode($_GET['vis_mode']) : json_encode("")); ?>;
-                if( vis_mode === "authors") {
+            if (<?php echo json_encode($_GET['service']) ?> === "linkedcat" ||
+                <?php echo json_encode($_GET['service']) ?> === "linkedcat_authorview" ||
+                <?php echo json_encode($_GET['service']) ?> === "linkedcat_browseview") {
+                if(<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "authors") {
                     data_config.is_authorview = true;
                 }
-                if( vis_type === "timeline") {
+                if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
                     data_config.is_streamgraph = true;
                     //data_config.embed_modal = false;
                     data_config.show_area = false;
 
-                    if( vis_mode === "authors") {
+                    if(<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "authors") {
                         data_config.intro = "";
                     } else {
                         data_config.intro = "";
                     }
                 } else {
-                    if (vis_type === "overview") {
-                        if(vis_mode === "authors") {
+                    if (<?php echo json_encode($_GET['vis_type']) ?> === "overview") {
+                        if(<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "authors") {
                             data_config.intro = "";
-                        } else if (vis_mode === "browse") {
+                        } else if (<?php echo json_encode(isset($_GET['vis_mode']) && $_GET['vis_mode']) ?> === "browse") {
                             data_config.intro = "";
                         } else {
                             data_config.intro = "";

--- a/server/services/snapshot/headstart_snapshot.php
+++ b/server/services/snapshot/headstart_snapshot.php
@@ -17,11 +17,11 @@
             data_config.show_context = true;
             data_config.create_title_from_context= true;
             data_config.options = options_<?php echo $_GET['service']; ?>.dropdowns;
-            var service = <?php echo (isset($_GET['service']) ? json_encode($_GET['service']) : json_encode("")) ?>;
-            var vis_type = <?php echo (isset($_GET['vis_type']) ? json_encode($_GET['vis_type']) : json_encode("")) ?>;
-            var vis_mode = <?php echo (isset($_GET['vis_mode']) ? json_encode($_GET['vis_mode']) : json_encode("")) ?>;
+            var service = <?php echo $_GET['service']; ?>;
             var special_services = ["linkedcat", "linkedcat_authorview", "linkedcat_browseview"];
             if ( special_services.includes(service) ) {
+                var vis_type = <?php echo (isset($_GET['vis_type']) ? json_encode($_GET['vis_type']) : json_encode("")); ?>;
+                var vis_mode = <?php echo (isset($_GET['vis_mode']) ? json_encode($_GET['vis_mode']) : json_encode("")); ?>;
                 if( vis_mode === "authors") {
                     data_config.is_authorview = true;
                 }


### PR DESCRIPTION
This PR fixes the last remaining parameter issues and activates snapshots for Linkedcat.

* linkedcat config added to Snapshot backend
* A new route has been added that passes the vis_type parameter on to the snapshot function, with this snapshots are now also possible for streamgraphs.
* A few other files along the pipeline had to be changed as well (fix variable naming inconsistencies), to ensure that variable names that influence both visualization outcome and URL forwarding follow the same convention. Otherwise the Snapshotting backend would not find the visualization in author mode and browse mode.

Functionality and snapshotting has been tested for author overviews and streamgraphs, keyword overviews and streamgraphs, and browseview maps; by manual search awaiting successful loading, and downloading the created PNGs and viewing them.