### PR TITLE
Linkedcat backend - multiword, phrase and negative keyword search

### DIFF
--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -192,6 +192,10 @@ boost_factors <- list(
   'keyword_label'=30
 )
 
+proximity_factors <- list(
+  'ocrtext'=7
+)
+
 build_authorfield_query <- function(field, query) {
   paste0(field, ':', '"', paste0(gsub("[^a-zA-Z<>]+", "*", query), "*"), '"', add_boost_factor(field))
 }
@@ -203,13 +207,15 @@ build_queryfield_query <- function(field, query) {
     for (i in 1:l_q) {
       query <- gsub('("[\\w+ äöü]+) AND ([äöü\\w \\.]+")', "\\1 \\2", query, perl=TRUE)
     }
-    query <- paste0(field, ':', '(', query, ')', add_boost_factor(field))
+    query <- paste0(field, ':', '(', query, ')', add_boost_factor(field), add_prox_factor(field))
   } else {
-    query <- paste0(field, ':', '"', query, '"', add_boost_factor(field))
+    query <- paste0(field, ':', '"', query, '"', add_boost_factor(field), add_prox_factor(field))
   }
 }
 
-
+add_prox_factor <- function(field) {
+  if (field %in% names(proximity_factors)) paste0('~', proximity_factors[field]) else ""
+}
 
 add_boost_factor <- function(field) {
   if (field %in% names(boost_factors)) paste0('^', boost_factors[field]) else ""

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -140,6 +140,7 @@ build_query <- function(query, params, limit){
                 'tags', 'category', 'bib', 'language_code',
                 'ocrtext', 'goobi_link')
   query <- gsub(" ?<<von>>", "", query)
+  query <- trimws(query, "both")
   aq <- paste0(lapply(a_fields, build_authorfield_query, query=query))
   qq <- paste0(lapply(q_fields, build_queryfield_query, query=query))
   q <- paste(c(aq, qq), collapse = " OR ")

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -107,10 +107,10 @@ get_papers <- function(query, params, limit=100) {
 
 clean_highlights <- function(query, res) {
   query <- gsub('"', '', query)
-  query <- gsub("[ ]+\\+[ ]+", " ", query)
+  query <- gsub("\\+|-", "", query, perl=TRUE)
   res$high$ocrtext <- unlist(lapply(res$high$ocrtext, function(x) {
     s <- strsplit(x, " \\.\\.\\. ")
-    unlist(lapply(s, function(x) x[grepl(paste0("<em>", gsub(" |-", "|", query), "</em>"), x, ignore.case=TRUE)]))[1]
+    unlist(lapply(s, function(x) x[grepl(paste0("<em>", gsub(" +", "|", query), "</em>"), x, ignore.case=TRUE)]))[1]
   }))
   res$high$ocrtext <- unlist(lapply(res$high$ocrtext, function(x) {
     gsub(paste0("<em>((?!", gsub(" ", "|", query), ").)<\\/em>"), "\\1", x, ignore.case=TRUE, perl=TRUE)
@@ -143,7 +143,7 @@ build_query <- function(query, params, limit){
   query <- gsub(" ?<<von>>", "", query)
   query <- trimws(query, "both")
   query <- gsub("-[ ]+", "-", query)
-  query <- gsub("[ ]+\\+[ ]+", " ", query)
+  query <- gsub("[ ]+\\+[ ]*", " ", query)
   aq <- paste0(lapply(a_fields, build_authorfield_query, query=query))
   qq <- paste0(lapply(q_fields, build_queryfield_query, query=query))
   q <- paste(c(aq, qq), collapse = " OR ")

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -107,6 +107,7 @@ get_papers <- function(query, params, limit=100) {
 
 clean_highlights <- function(query, res) {
   query <- gsub('"', '', query)
+  query <- gsub("[ ]+\\+[ ]+", " ", query)
   res$high$ocrtext <- unlist(lapply(res$high$ocrtext, function(x) {
     s <- strsplit(x, " \\.\\.\\. ")
     unlist(lapply(s, function(x) x[grepl(paste0("<em>", gsub(" |-", "|", query), "</em>"), x, ignore.case=TRUE)]))[1]
@@ -142,6 +143,7 @@ build_query <- function(query, params, limit){
   query <- gsub(" ?<<von>>", "", query)
   query <- trimws(query, "both")
   query <- gsub("-[ ]+", "-", query)
+  query <- gsub("[ ]+\\+[ ]+", " ", query)
   aq <- paste0(lapply(a_fields, build_authorfield_query, query=query))
   qq <- paste0(lapply(q_fields, build_queryfield_query, query=query))
   q <- paste(c(aq, qq), collapse = " OR ")

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -141,6 +141,7 @@ build_query <- function(query, params, limit){
                 'ocrtext', 'goobi_link')
   query <- gsub(" ?<<von>>", "", query)
   query <- trimws(query, "both")
+  query <- gsub("-[ ]+", "-", query)
   aq <- paste0(lapply(a_fields, build_authorfield_query, query=query))
   qq <- paste0(lapply(q_fields, build_queryfield_query, query=query))
   q <- paste(c(aq, qq), collapse = " OR ")

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -195,10 +195,6 @@ boost_factors <- list(
   'keyword_label'=30
 )
 
-proximity_factors <- list(
-  'ocrtext'=7
-)
-
 build_authorfield_query <- function(field, query) {
   paste0(field, ':', '"', paste0(gsub("[^a-zA-Z<>]+", "*", query), "*"), '"', add_boost_factor(field))
 }
@@ -210,14 +206,10 @@ build_queryfield_query <- function(field, query) {
     for (i in 1:l_q) {
       query <- gsub('("[\\w+ äöü]+) AND ([äöü\\w \\.]+")', "\\1 \\2", query, perl=TRUE)
     }
-    query <- paste0(field, ':', '(', query, ')', add_boost_factor(field), add_prox_factor(field))
+    query <- paste0(field, ':', '(', query, ')', add_boost_factor(field))
   } else {
-    query <- paste0(field, ':', '"', query, '"', add_boost_factor(field), add_prox_factor(field))
+    query <- paste0(field, ':', '"', query, '"', add_boost_factor(field))
   }
-}
-
-add_prox_factor <- function(field) {
-  if (field %in% names(proximity_factors)) paste0('~', proximity_factors[field]) else ""
 }
 
 add_boost_factor <- function(field) {

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -191,7 +191,7 @@ boost_factors <- list(
   'keyword_label'=30
 )
 
-build_authorfield_query <- function(field) {
+build_authorfield_query <- function(field, query) {
   paste0(field, ':', '"', paste0(gsub("[^a-zA-Z<>]+", "*", query), "*"), '"', add_boost_factor(field))
 }
 

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -196,8 +196,8 @@ build_authorfield_query <- function(field, query) {
 
 build_queryfield_query <- function(field, query) {
   if (length(unlist(strsplit(query, " "))) > 1) {
-    query <- paste0(unlist(strsplit(query, " ")), collapse = " AND ")
-    query <- paste0(field, ':', '(', query, ')', add_boost_factor(field))
+    query <- paste0(unlist(strsplit(query, " ")), collapse = '" AND "')
+    query <- paste0(field, ':', '("', query, '")', add_boost_factor(field))
   } else {
     query <- paste0(field, ':', '"', query, '"', add_boost_factor(field))
   }

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -107,7 +107,7 @@ get_papers <- function(query, params, limit=100) {
 
 clean_highlights <- function(query, res) {
   query <- gsub('"', '', query)
-  query <- gsub("\\+|-", "", query, perl=TRUE)
+  query <- gsub("[\\+ ]+|-", " ", query, perl=TRUE)
   res$high$ocrtext <- unlist(lapply(res$high$ocrtext, function(x) {
     s <- strsplit(x, " \\.\\.\\. ")
     unlist(lapply(s, function(x) x[grepl(paste0("<em>", gsub(" +", "|", query), "</em>"), x, ignore.case=TRUE)]))[1]

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -200,7 +200,7 @@ build_queryfield_query <- function(field, query) {
   if (l_q > 1) {
     query <- gsub(" ", " AND ", query, perl=TRUE)
     for (i in 1:l_q) {
-      query <- gsub('("[\\w+ ]+) AND ([\\w \\.]+")', "\\1 \\2", query, perl=TRUE)
+      query <- gsub('("[\\w+ äöü]+) AND ([äöü\\w \\.]+")', "\\1 \\2", query, perl=TRUE)
     }
     query <- paste0(field, ':', '(', query, ')', add_boost_factor(field))
   } else {

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -203,9 +203,10 @@ build_queryfield_query <- function(field, query) {
   l_q <- length(unlist(strsplit(query, " ")))
   if (l_q > 1) {
     query <- gsub(" ", " AND ", query, perl=TRUE)
-    for (i in 1:l_q) {
-      query <- gsub('("[\\w+ äöü]+) AND ([äöü\\w \\.]+")', "\\1 \\2", query, perl=TRUE)
+    for (i in 1:l_q*l_q) {
+      query <- gsub('(\\-?"[\\w+ äöü]+) AND ([äöü\\w \\.]+")', "\\1 \\2", query, perl=TRUE)
     }
+    query <- gsub(' AND -', ' -', query)
     query <- paste0(field, ':', '(', query, ')', add_boost_factor(field))
   } else {
     query <- paste0(field, ':', '"', query, '"', add_boost_factor(field))

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -142,6 +142,7 @@ build_query <- function(query, params, limit){
                 'ocrtext', 'goobi_link')
   query <- gsub(" ?<<von>>", "", query)
   query <- trimws(query, "both")
+  query <- gsub("\\s+", " ", query)
   query <- gsub("-[ ]+", "-", query)
   query <- gsub("[ ]+\\+[ ]*", " ", query)
   aq <- paste0(lapply(a_fields, build_authorfield_query, query=query))

--- a/server/preprocessing/other-scripts/linkedcat.R
+++ b/server/preprocessing/other-scripts/linkedcat.R
@@ -109,7 +109,7 @@ clean_highlights <- function(query, res) {
   query <- gsub('"', '', query)
   res$high$ocrtext <- unlist(lapply(res$high$ocrtext, function(x) {
     s <- strsplit(x, " \\.\\.\\. ")
-    unlist(lapply(s, function(x) x[grepl(paste0("<em>", gsub(" ", "|", query), "</em>"), x, ignore.case=TRUE)]))[1]
+    unlist(lapply(s, function(x) x[grepl(paste0("<em>", gsub(" |-", "|", query), "</em>"), x, ignore.case=TRUE)]))[1]
   }))
   res$high$ocrtext <- unlist(lapply(res$high$ocrtext, function(x) {
     gsub(paste0("<em>((?!", gsub(" ", "|", query), ").)<\\/em>"), "\\1", x, ignore.case=TRUE, perl=TRUE)

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -44,6 +44,7 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
     $ini_array = library\Toolkit::loadIni($INI_DIR);
     $query = strip_tags($dirty_query);
     $query = trim($query);
+    $query = preg_replace('!\s+!', ' ', $query);
 
     if ($transform_query_tolowercase) {
         $query = strtolower($query);

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -42,6 +42,7 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
         , $retrieve_cached_map = true, $params_for_id = null, $num_labels = 3, $id = "area_uri", $subjects = "subject") {
     $INI_DIR = dirname(__FILE__) . "/../preprocessing/conf/";
     $ini_array = library\Toolkit::loadIni($INI_DIR);
+    $query = trim($query);
     $query = strip_tags($dirty_query);
 
     if ($transform_query_tolowercase) {

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -44,7 +44,6 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
     $ini_array = library\Toolkit::loadIni($INI_DIR);
     $query = strip_tags($dirty_query);
     $query = trim($query);
-    $query = preg_replace('!\s+!', ' ', $query);
 
     if ($transform_query_tolowercase) {
         $query = strtolower($query);

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -42,8 +42,8 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
         , $retrieve_cached_map = true, $params_for_id = null, $num_labels = 3, $id = "area_uri", $subjects = "subject") {
     $INI_DIR = dirname(__FILE__) . "/../preprocessing/conf/";
     $ini_array = library\Toolkit::loadIni($INI_DIR);
-    $query = trim($query);
     $query = strip_tags($dirty_query);
+    $query = trim($query);
 
     if ($transform_query_tolowercase) {
         $query = strtolower($query);


### PR DESCRIPTION
This PR updates keyword searches: Multiple words, exact phrases, and negative keywords are now working as intended. Highlighting of more than one word now also works.

Please compare following maps/streamgraphs:
* Kaiser Leopold I
* "Kaiser Leopold I"
* Kaiser Leopold II
* "Kaiser Leopold II"
* Leopold -Kaiser -II
* hund
* hund wolf
* hund -wolf
* -hund wolf
* Ferdinand Wolf
* "Ferdinand Wolf" 
* "Ferdinand Wolf" Houdene
* "Ferdinand Wolf" -Houdene
* Ferdinand Wolf -Mundart
* Ferdinand Wolf Mundart