### PR TITLE
Enable a fallback AJAX search request on the client

### DIFF
--- a/server/services/getLastVersion.php
+++ b/server/services/getLastVersion.php
@@ -1,0 +1,25 @@
+<?php
+
+header('Content-type: application/json');
+
+require dirname(__FILE__) . '/../classes/headstart/persistence/SQLitePersistence.php';
+require_once dirname(__FILE__) . '/../classes/headstart/library/CommUtils.php';
+require_once dirname(__FILE__) . '/../classes/headstart/library/toolkit.php';
+
+use headstart\library;
+
+$INI_DIR = dirname(__FILE__) . "/../preprocessing/conf/";
+
+$ini_array = library\Toolkit::loadIni($INI_DIR);
+
+$vis_id = library\CommUtils::getParameter($_GET, "vis_id");
+
+$persistence = new headstart\persistence\SQLitePersistence($ini_array["connection"]["sqlite_db"]);
+
+$last_version = $persistence->getLastVersion($vis_id, false);
+
+if ($last_version != null && $last_version != "null" && $last_version != false) {
+    echo json_encode(array("status" => "success", "last_version" => $last_version));
+} else {
+    echo json_encode(array("status" => "error"));
+}

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -47,6 +47,8 @@ function cleanQuery($dirty_query, $transform_query_tolowercase) {
     }
     
     $query = addslashes($query);
+    
+    return $query;
 }
 
 function search($repository, $dirty_query, $post_params, $param_types, $keyword_separator, $taxonomy_separator, $transform_query_tolowercase = true

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -38,18 +38,25 @@ function utf8_converter($array)
     return $array;
 }
 
+function cleanQuery($dirty_query, $transform_query_tolowercase) {
+    $query = strip_tags($dirty_query);
+    $query = trim($query);
+    
+    if ($transform_query_tolowercase) {
+        $query = strtolower($query);
+    }
+    
+    $query = addslashes($query);
+}
+
 function search($repository, $dirty_query, $post_params, $param_types, $keyword_separator, $taxonomy_separator, $transform_query_tolowercase = true
         , $retrieve_cached_map = true, $params_for_id = null, $num_labels = 3, $id = "area_uri", $subjects = "subject", $precomputed_id = null) {
     $INI_DIR = dirname(__FILE__) . "/../preprocessing/conf/";
     $ini_array = library\Toolkit::loadIni($INI_DIR);
-    $query = strip_tags($dirty_query);
-    $query = trim($query);
-
-    if ($transform_query_tolowercase) {
-        $query = strtolower($query);
-    }
-
-    $query = addslashes($query);
+     
+    $query = ($precomputed_id === null)
+                ?(cleanQuery($dirty_query, $transform_query_tolowercase))
+                :($dirty_query);
 
     $persistence = new \headstart\persistence\SQLitePersistence($ini_array["connection"]["sqlite_db"]);
 

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -52,11 +52,11 @@ function cleanQuery($dirty_query, $transform_query_tolowercase) {
 }
 
 function search($repository, $dirty_query, $post_params, $param_types, $keyword_separator, $taxonomy_separator, $transform_query_tolowercase = true
-        , $retrieve_cached_map = true, $params_for_id = null, $num_labels = 3, $id = "area_uri", $subjects = "subject", $precomputed_id = null) {
+        , $retrieve_cached_map = true, $params_for_id = null, $num_labels = 3, $id = "area_uri", $subjects = "subject", $precomputed_id = null, $do_clean_query = true) {
     $INI_DIR = dirname(__FILE__) . "/../preprocessing/conf/";
     $ini_array = library\Toolkit::loadIni($INI_DIR);
      
-    $query = ($precomputed_id === null)
+    $query = ($do_clean_query === true)
                 ?(cleanQuery($dirty_query, $transform_query_tolowercase))
                 :($dirty_query);
 

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -39,7 +39,7 @@ function utf8_converter($array)
 }
 
 function search($repository, $dirty_query, $post_params, $param_types, $keyword_separator, $taxonomy_separator, $transform_query_tolowercase = true
-        , $retrieve_cached_map = true, $params_for_id = null, $num_labels = 3, $id = "area_uri", $subjects = "subject") {
+        , $retrieve_cached_map = true, $params_for_id = null, $num_labels = 3, $id = "area_uri", $subjects = "subject", $precomputed_id = null) {
     $INI_DIR = dirname(__FILE__) . "/../preprocessing/conf/";
     $ini_array = library\Toolkit::loadIni($INI_DIR);
     $query = strip_tags($dirty_query);
@@ -58,7 +58,7 @@ function search($repository, $dirty_query, $post_params, $param_types, $keyword_
 
     $params_for_id_creation = ($params_for_id === null)?($params_json):(packParamsJSON($params_for_id, $post_params));
 
-    $unique_id = $persistence->createID(array($query, $params_for_id_creation));
+    $unique_id = ($precomputed_id === null)?($persistence->createID(array($query, $params_for_id_creation))):($precomputed_id);
 
     if($retrieve_cached_map) {
         $last_version = $persistence->getLastVersion($unique_id, false);

--- a/server/services/searchBASE.php
+++ b/server/services/searchBASE.php
@@ -15,7 +15,7 @@ $post_params = $_POST;
 $result = search("base", $dirty_query, $post_params
                     , array("from", "to", "document_types", "sorting")
                     , ";", null, true, true, null, 3
-                    , "area_uri", "subject", $precomputed_id);
+                    , "area_uri", "subject", $precomputed_id, false);
 
 echo $result
 

--- a/server/services/searchBASE.php
+++ b/server/services/searchBASE.php
@@ -8,11 +8,14 @@ require 'search.php';
 use headstart\library;
 
 $dirty_query = library\CommUtils::getParameter($_POST, "q");
-$precomputed_id = library\CommUtils::getParameter($_POST, "unique_id");
+$precomputed_id = (isset($_POST["unique_id"]))?($_POST["unique_id"]):(null);
 
 $post_params = $_POST;
 
-$result = search("base", $dirty_query, $post_params, array("from", "to", "document_types", "sorting"), ";", null, true, true, null, 3, "area_uri", "subject", $precomputed_id);
+$result = search("base", $dirty_query, $post_params
+                    , array("from", "to", "document_types", "sorting")
+                    , ";", null, true, true, null, 3
+                    , "area_uri", "subject", $precomputed_id);
 
 echo $result
 

--- a/server/services/searchBASE.php
+++ b/server/services/searchBASE.php
@@ -8,10 +8,11 @@ require 'search.php';
 use headstart\library;
 
 $dirty_query = library\CommUtils::getParameter($_POST, "q");
+$precomputed_id = library\CommUtils::getParameter($_POST, "unique_id");
 
 $post_params = $_POST;
 
-$result = search("base", $dirty_query, $post_params, array("from", "to", "document_types", "sorting"), ";", null);
+$result = search("base", $dirty_query, $post_params, array("from", "to", "document_types", "sorting"), ";", null, true, true, null, 3, "area_uri", "subject", $precomputed_id);
 
 echo $result
 

--- a/server/services/searchDOAJ.php
+++ b/server/services/searchDOAJ.php
@@ -8,10 +8,14 @@ require 'search.php';
 use headstart\library;
 
 $dirty_query = library\CommUtils::getParameter($_POST, "q");
+$precomputed_id = (isset($_POST["unique_id"]))?($_POST["unique_id"]):(null);
 
 $post_params = $_POST;
 
-$result = search("doaj", $dirty_query, $post_params, array("from", "to", "today", "sorting"), ";", null);
+$result = search("doaj", $dirty_query, $post_params
+                    , array("from", "to", "today", "sorting")
+                    , ";", null, true, true, null, 3
+                    , "area_uri", "subject", $precomputed_id);
 
 echo $result
 

--- a/server/services/searchDOAJ.php
+++ b/server/services/searchDOAJ.php
@@ -15,7 +15,7 @@ $post_params = $_POST;
 $result = search("doaj", $dirty_query, $post_params
                     , array("from", "to", "today", "sorting")
                     , ";", null, true, true, null, 3
-                    , "area_uri", "subject", $precomputed_id);
+                    , "area_uri", "subject", $precomputed_id, false);
 
 echo $result
 

--- a/server/services/searchPLOS.php
+++ b/server/services/searchPLOS.php
@@ -8,10 +8,14 @@ require 'search.php';
 use headstart\library;
 
 $dirty_query = library\CommUtils::getParameter($_POST, "q");
+$precomputed_id = (isset($_POST["unique_id"]))?($_POST["unique_id"]):(null);
 
 $post_params = $_POST;
 
-$result = search("plos", $dirty_query, $post_params, array("article_types", "journals", "from", "to", "sorting"), ";", "/");
+$result = search("plos", $dirty_query, $post_params
+                    , array("article_types", "journals", "from", "to", "sorting")
+                    , ";", "/", true, true, null, 3
+                    , "area_uri", "subject", $precomputed_id);
 
 echo $result
 

--- a/server/services/searchPLOS.php
+++ b/server/services/searchPLOS.php
@@ -15,7 +15,7 @@ $post_params = $_POST;
 $result = search("plos", $dirty_query, $post_params
                     , array("article_types", "journals", "from", "to", "sorting")
                     , ";", "/", true, true, null, 3
-                    , "area_uri", "subject", $precomputed_id);
+                    , "area_uri", "subject", $precomputed_id, false);
 
 echo $result
 

--- a/server/services/searchPubmed.php
+++ b/server/services/searchPubmed.php
@@ -17,7 +17,7 @@ $post_params = $_POST;
 $result = search("pubmed", $dirty_query
                     , $post_params, array("from", "to", "sorting")
                     , ";", null, true, true, null, 3
-                    , "area_uri", "subject", $precomputed_id);
+                    , "area_uri", "subject", $precomputed_id, false);
 
 echo $result
 

--- a/server/services/searchPubmed.php
+++ b/server/services/searchPubmed.php
@@ -8,12 +8,16 @@ require 'search.php';
 use headstart\library;
 
 $dirty_query = library\CommUtils::getParameter($_POST, "q");
+$precomputed_id = (isset($_POST["unique_id"]))?($_POST["unique_id"]):(null);
 
 $post_params = $_POST;
 
 #HOTFIX - article_types cause a 414 with PubMed
 #$result = search("pubmed", $dirty_query, $post_params, array("article_types", "from", "to", "sorting"), ";", null);
-$result = search("pubmed", $dirty_query, $post_params, array("from", "to", "sorting"), ";", null);
+$result = search("pubmed", $dirty_query
+                    , $post_params, array("from", "to", "sorting")
+                    , ";", null, true, true, null, 3
+                    , "area_uri", "subject", $precomputed_id);
 
 echo $result
 


### PR DESCRIPTION
This PR introduces two changes, which enable users of Head Start to implement a fallback AJAX search request, should the original request to the search*.php service not return (this is for example the case with bad connections):

1. A service getLastVersion.php that returns the last version of a map for a given ID (used to check if a map/a specific revision has been created).
2. Add the ability to provide search.php with a precomputed ID (otherwise, the client does not know, what map ID to check for).

This change was tested with all existing examples.