### PR TITLE
Force single instance of Headstart

### DIFF
--- a/vis/app.js
+++ b/vis/app.js
@@ -12,8 +12,8 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 var start = function(json_data) {
     if(data_config) Object.assign(config, data_config);
     window.namespace = "headstart";
-    var headstartInstance = new hs.HeadstartFSM(json_data);
-    headstartInstance.start();
+    window.headstartInstance = new hs.HeadstartFSM(json_data);
+    window.headstartInstance.start();
 }
 
 export {start};

--- a/vis/js/canvas.js
+++ b/vis/js/canvas.js
@@ -1,6 +1,5 @@
 import { getRealHeight } from "helpers";
 import config from 'config';
-import { headstart } from 'headstart';
 import { papers } from 'papers';
 import { mediator } from 'mediator';
 import { intros } from 'intro';
@@ -51,7 +50,7 @@ class Canvas {
 
         this.available_height = this.available_height - ((toolbar_height > 0)?(CHART_HEIGHT_CORRECTION_TOOLBAR):(CHART_HEIGHT_CORRECTION));
 
-        if (headstart.is("multiples")) {
+        if (window.headstartInstance.is("multiples")) {
             var multiples_height = $(".tl-title").outerHeight(true);
             this.available_height = this.available_height - multiples_height;
             this.available_width = $("#" + config.tag).width();
@@ -221,7 +220,7 @@ class Canvas {
     initEventListeners() {
         d3.select(window).on("resize", () => {
             mediator.publish("record_action", config.title, "Map", "resize", config.user_id, "resize_map", null, null, null);
-            if (headstart.is("multiples")) {
+            if (window.headstartInstance.is("multiples")) {
                 return;
             }   
             mediator.publish("window_resize");
@@ -400,7 +399,7 @@ class Canvas {
             $("#datasets").change(function () {
                 let selected_file_number = this.selectedIndex;
                 if (selected_file_number !== mediator.current_file_number) {
-                    headstart.tofile(selected_file_number);
+                    window.headstartInstance.tofile(selected_file_number);
                 }
             });
         }
@@ -723,12 +722,12 @@ class Canvas {
     }
 
     initForceAreas() {
-        let padded = canvas.current_vis_size - headstart.padding;
+        let padded = canvas.current_vis_size - window.headstartInstance.padding;
         this.force_areas = d3.layout.force().links([]).size([padded, padded]);
     }
 
     initForcePapers() {
-        let padded = canvas.current_vis_size - headstart.padding;
+        let padded = canvas.current_vis_size - window.headstartInstance.padding;
         this.force_papers = d3.layout.force().nodes([]).links([]).size([padded, padded]);
     }
 

--- a/vis/js/mediator.js
+++ b/vis/js/mediator.js
@@ -1,4 +1,3 @@
-import { headstart } from 'headstart';
 import Mediator from 'mediator-js';
 import config from 'config';
 import { papers } from 'papers';
@@ -195,7 +194,7 @@ MyMediator.prototype = {
     io_async_get_data: function (url, input_format, callback) {
         // WORKAROUND, if I try to add headstart earlier it doesn't work
         // TODO find reason
-        mediator.modules.headstart = headstart;
+        mediator.modules.headstart = window.headstartInstance;
         mediator.manager.call('io', 'async_get_data', [url, input_format, callback]);
     },
 
@@ -272,7 +271,7 @@ MyMediator.prototype = {
         let context = (typeof csv.context !== 'object')?({}):(csv.context);
         mediator.streamgraph_data = (config.is_streamgraph)?(csv.streamgraph):{};
         
-        mediator.manager.registerModule(headstart, 'headstart');
+        mediator.manager.registerModule(window.headstartInstance, 'headstart');
         
         if(config.is_streamgraph) {         
             mediator.manager.call('canvas', 'setupStreamgraphCanvas', []);
@@ -587,11 +586,11 @@ MyMediator.prototype = {
     },
 
     record_action: function(id, category, action, user, type, timestamp, additional_params, post_data) {
-        headstart.recordAction(id, category, action, user, type, timestamp, additional_params, post_data);
+        window.headstartInstance.recordAction(id, category, action, user, type, timestamp, additional_params, post_data);
     },
     
     mark_project_changed: function(id) {
-        headstart.markProjectChanged(id);
+        window.headstartInstance.markProjectChanged(id);
     },
 
     window_resize: function() {

--- a/vis/js/scale.js
+++ b/vis/js/scale.js
@@ -1,7 +1,5 @@
 import config from 'config';
 import { mediator } from 'mediator';
-import { canvas } from 'canvas'
-import { headstart } from 'headstart'
 
 class Scale {
   constructor (scaleTypes) {
@@ -60,7 +58,7 @@ class Scale {
             config.content_based = false;
             config.initial_sort = config.scale_base_unit[type];
         }
-        headstart.tofile(mediator.current_file_number)
+        window.headstartInstance.tofile(mediator.current_file_number)
     } else {
         mediator.publish("update_visual_distributions", type);
     }


### PR DESCRIPTION
Fixes dropdown in local_files.

Probably fixes scaling in Viper.

Prior to the webpack 4 version increase it seems that a single
instance of headstart was used throughout the application.

This seems to have been been possible by manipulating the
headstart alias imported in app.js. It wasn't possible to continue
this pattern with webpack 4. I'm unsure the exact reason why but
doing this is probably not advised anyway.

This patch forces an explict global headstart object and ensures
the callers in mediator, canvas and scale all use it.

This is probably not the ideal solution. It might be better to
instead properly inject headstart into the places that need it.