### PR TITLE
Triple streamgraph backend

### DIFF
--- a/examples/triple/config_example.php
+++ b/examples/triple/config_example.php
@@ -1,0 +1,5 @@
+<?php
+$HEADSTART_PATH = "../../";
+$WEBSITE_PATH = "http://localhost/triple/";
+$SNAPSHOT_PATH = $WEBSITE_PATH . "server/storage/";
+?>

--- a/examples/triple/data-config_triple.js
+++ b/examples/triple/data-config_triple.js
@@ -14,6 +14,7 @@ var data_config = {
     is_force_areas: true,
     language: "eng_pubmed",
     area_force_alpha: 0.015,
+    show_keywords: true,
     show_list: true,
     content_based: true,
     url_prefix: "",

--- a/examples/triple/data-config_triple.js
+++ b/examples/triple/data-config_triple.js
@@ -29,4 +29,6 @@ var data_config = {
 
     embed_modal: true,
     share_modal: false,
+
+    backend: "api"
 };

--- a/examples/triple/headstart.php
+++ b/examples/triple/headstart.php
@@ -1,6 +1,14 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<?php
+include 'config.php';
+?>
 <html>
     <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+      <?php
+          $id = $_GET["file"];
+          $query = $_GET["query"];
+          $vis_type = $_GET["vis_type"];
+      ?>
     </head>
 
     <body style="margin:0px; padding:0px">
@@ -10,15 +18,23 @@
         <script type="text/javascript" src="data-config_server.js"></script>
         <script type="text/javascript" src="search_options.js"></script>
         <script>
-            data_config.title = '<?php echo 'Overview of <span id="search-term-unique">' . $_GET['query'] . '</span>'; ?>';
+            data_config.server_url = window.location.href.replace(/[^/]*$/, '') + "<?php echo $HEADSTART_PATH; ?>server/";
         	data_config.files = [{
         		title: <?php echo json_encode($_GET['query']) ?>,
         		file: <?php echo json_encode($_GET['file']) ?>
         	}];
                 data_config.options = options_<?php echo $_GET['service'] ?>.dropdowns;
+                if(<?php echo json_encode($_GET['vis_type']) ?> === "timeline") {
+                    data_config.is_streamgraph = true;
+                    //data_config.embed_modal = false;
+                    data_config.show_area = false;
+                } else {
+                    if (<?php echo json_encode($_GET['vis_type']) ?> === "overview") {
+                    }
+                }
         </script>
-        <script type="text/javascript" src="../../dist/headstart.js"></script>
-        <link type="text/css" rel="stylesheet" href="../../dist/headstart.css"></link>
+        <script type="text/javascript" src="<?php echo $HEADSTART_PATH; ?>dist/headstart.js"></script>
+        <link type="text/css" rel="stylesheet" href="<?php echo $HEADSTART_PATH; ?>dist/headstart.css"></link>
         <script type="text/javascript">
             headstart.start();
         </script>

--- a/examples/triple/search.js
+++ b/examples/triple/search.js
@@ -1,6 +1,7 @@
 var service_url;
 var service_name;
 var options;
+var vis_type;
 
 switch (data_config.service) {
     case 'plos':
@@ -44,6 +45,7 @@ $(window).bind("pageshow", function () {
 
 $("#searchform").validate({
     submitHandler: function (form) {
+        console.log(form);
         $(".btn").attr("disabled", true);
         $("#progress").html("");
 
@@ -75,6 +77,11 @@ $("#searchform").validate({
 
 var doSubmit = function (data, newWindow, callback) {
   data += "&today=" + new Date().toLocaleDateString("en-US");
+  var params = $("#searchform").serializeArray().reduce(function(obj, item) {
+    obj[item.name] = item.value;
+    return obj;
+  }, {});
+  vis_type = params["vis_type"];
 
   var openInNewWindow= function(data) {
     if (data.status === "success") {
@@ -108,7 +115,7 @@ var doSubmit = function (data, newWindow, callback) {
         "&service_name=" +
         service_name +
         "&vis_type=" +
-        data.vis_type;
+        vis_type;
       return false;
     } else {
       $("#progress").html(

--- a/examples/triple/search.js
+++ b/examples/triple/search.js
@@ -106,7 +106,9 @@ var doSubmit = function (data, newWindow, callback) {
         "&service=" +
         data_config.service +
         "&service_name=" +
-        service_name;
+        service_name +
+        "&vis_type=" +
+        data.vis_type;
       return false;
     } else {
       $("#progress").html(

--- a/examples/triple/search_options.js
+++ b/examples/triple/search_options.js
@@ -15,6 +15,11 @@ var options_triple = {
             , fields: [
                 {id: "most-relevant", text: "Most relevant"}
                 , {id: "most-recent", text: "Most recent"}
+            ]},
+        {id: "vis_type", multiple: false, name: "Visualization Type", type: "dropdown"
+            , fields: [
+                {id: "streamgraph", text: "Timeline"},
+                {id: "overview", text: "Knowledge Map"}
             ]}
     ]}
 

--- a/examples/triple/search_options.js
+++ b/examples/triple/search_options.js
@@ -15,11 +15,6 @@ var options_triple = {
             , fields: [
                 {id: "most-relevant", text: "Most relevant"}
                 , {id: "most-recent", text: "Most recent"}
-            ]},
-        {id: "vis_type", multiple: false, name: "Visualization Type", type: "dropdown"
-            , fields: [
-                {id: "timeline", text: "Timeline"},
-                {id: "overview", text: "Knowledge Map"}
             ]}
     ]}
 

--- a/examples/triple/search_options.js
+++ b/examples/triple/search_options.js
@@ -18,7 +18,7 @@ var options_triple = {
             ]},
         {id: "vis_type", multiple: false, name: "Visualization Type", type: "dropdown"
             , fields: [
-                {id: "streamgraph", text: "Timeline"},
+                {id: "timeline", text: "Timeline"},
                 {id: "overview", text: "Knowledge Map"}
             ]}
     ]}

--- a/examples/triple/search_triple.php
+++ b/examples/triple/search_triple.php
@@ -33,6 +33,20 @@ include 'config.php';
             <input type="text" name="q" size="61" required>
             <button type="submit" class="btn">Submit</button>
             <div id="filter-container"></div>
+            <label class="radio-button">
+                <input type="radio" name="vis_type" value="overview" checked="checked">
+                <span class="checkmark"></span>
+                <span class="popover-selection">Knowledge Map
+                </span>
+            </label>
+            </div>
+            <div>
+            <label class="radio-button">
+                <input type="radio" name="vis_type" value="timeline">
+                <span class="checkmark"></span>
+                <span class=popover-selection>Streamgraph
+                </span>
+            </label>
         </form>
     </div>
     <div id="progress">

--- a/examples/triple/search_triple.php
+++ b/examples/triple/search_triple.php
@@ -4,6 +4,9 @@ To change this license header, choose License Headers in Project Properties.
 To change this template file, choose Tools | Templates
 and open the template in the editor.
 -->
+<?php
+include 'config.php';
+?>
 <html>
 
 <head>
@@ -38,8 +41,10 @@ and open the template in the editor.
     <div style="margin-top:20px ">Built with <a href="https://github.com/OpenKnowledgeMaps/Headstart" target="_blank ">Head Start</a>. All content retrieved from <a href="https://www.gotriple.eu/" target="_blank ">TRIPLE</a>.
     </div>
     <script type="text/javascript" src="data-config_triple.js"></script>
-    <script type="text/javascript" src="data-config_server.js"></script>
     <script type="text/javascript " src="search_options.js "></script>
+    <script type="text/javascript">
+      data_config.server_url = window.location.href.replace(/[^/]*$/, '') + "<?php echo $HEADSTART_PATH; ?>server/";
+    </script>
     <script type="text/javascript " src="search.js "></script>
 </body>
 

--- a/server/services/getLatestRevision.php
+++ b/server/services/getLatestRevision.php
@@ -18,11 +18,22 @@ $context = filter_input(INPUT_GET, "context", FILTER_VALIDATE_BOOLEAN,
     array("flags" => FILTER_NULL_ON_FAILURE));
 $streamgraph = filter_input(INPUT_GET, "streamgraph", FILTER_VALIDATE_BOOLEAN,
     array("flags" => FILTER_NULL_ON_FAILURE));
-$backend = isset($_GET["vis_id"]) ? library\CommUtils::getParameter($_GET, "vis_id") : "legacy";
+$backend = isset($_GET["backend"]) ? library\CommUtils::getParameter($_GET, "backend") : "legacy";
 
 $persistence = new headstart\persistence\SQLitePersistence($ini_array["connection"]["sqlite_db"]);
 
 if ($backend == "api") {
+  if ($context === true) {
+      $data = $persistence->getLastVersion($vis_id, $details = false, $context = true)[0];
+      $return_data = array("context" => array("id" => $data["rev_vis"], "query" => $data["vis_query"], "service" => $data["vis_title"]
+                              , "timestamp" => $data["rev_timestamp"], "params" => $data["vis_params"]),
+                          "data" => $data["rev_data"]);
+      $jsonData = json_encode($return_data);
+      library\CommUtils::echoOrCallback($jsonData, $_GET);
+      } else {
+          $jsonData = $persistence->getLastVersion($vis_id);
+          library\CommUtils::echoOrCallback($jsonData[0], $_GET);
+      }
 } else {
   if ($context === true) {
      $data = $persistence->getLastVersion($vis_id, $details = false, $context = true)[0];

--- a/server/services/getLatestRevision.php
+++ b/server/services/getLatestRevision.php
@@ -25,13 +25,11 @@ $persistence = new headstart\persistence\SQLitePersistence($ini_array["connectio
 if ($backend == "api") {
   if ($context === true) {
       $data = $persistence->getLastVersion($vis_id, $details = false, $context = true)[0];
-      $rev_data = json_decode($data["rev_data"], true);
-      $data = $rev_data["data"];
-      $sg_data = $rev_data["sg_data"];
+      $packed_data = json_decode($data["rev_data"], true);
       $return_data = array("context" => array("id" => $data["rev_vis"], "query" => $data["vis_query"], "service" => $data["vis_title"]
                               , "timestamp" => $data["rev_timestamp"], "params" => $data["vis_params"]),
-                          "data" => $data,
-                          "streamgraph" => $sg_data);
+                          "data" => $packed_data["data"],
+                          "streamgraph" => $packed_data["streamgraph"]);
       $jsonData = json_encode($return_data);
       library\CommUtils::echoOrCallback($jsonData, $_GET);
       } else {

--- a/server/services/getLatestRevision.php
+++ b/server/services/getLatestRevision.php
@@ -25,9 +25,13 @@ $persistence = new headstart\persistence\SQLitePersistence($ini_array["connectio
 if ($backend == "api") {
   if ($context === true) {
       $data = $persistence->getLastVersion($vis_id, $details = false, $context = true)[0];
+      $rev_data = json_decode($data["rev_data"], true);
+      $data = $rev_data["data"];
+      $sg_data = $rev_data["sg_data"];
       $return_data = array("context" => array("id" => $data["rev_vis"], "query" => $data["vis_query"], "service" => $data["vis_title"]
                               , "timestamp" => $data["rev_timestamp"], "params" => $data["vis_params"]),
-                          "data" => $data["rev_data"]);
+                          "data" => $data,
+                          "streamgraph" => $sg_data);
       $jsonData = json_encode($return_data);
       library\CommUtils::echoOrCallback($jsonData, $_GET);
       } else {

--- a/server/services/getLatestRevision.php
+++ b/server/services/getLatestRevision.php
@@ -25,13 +25,21 @@ $persistence = new headstart\persistence\SQLitePersistence($ini_array["connectio
 if ($backend == "api") {
   if ($context === true) {
       $data = $persistence->getLastVersion($vis_id, $details = false, $context = true)[0];
-      $packed_data = json_decode($data["rev_data"], true);
-      $return_data = array("context" => array("id" => $data["rev_vis"], "query" => $data["vis_query"], "service" => $data["vis_title"]
-                              , "timestamp" => $data["rev_timestamp"], "params" => $data["vis_params"]),
-                          "data" => $packed_data["data"],
-                          "streamgraph" => $packed_data["streamgraph"]);
-      $jsonData = json_encode($return_data);
-      library\CommUtils::echoOrCallback($jsonData, $_GET);
+      if ($streamgraph === true) {
+        $packed_data = json_decode($data["rev_data"], true);
+        $return_data = array("context" => array("id" => $data["rev_vis"], "query" => $data["vis_query"], "service" => $data["vis_title"]
+                                , "timestamp" => $data["rev_timestamp"], "params" => $data["vis_params"]),
+                            "data" => $packed_data["data"],
+                            "streamgraph" => $packed_data["streamgraph"]);
+        $jsonData = json_encode($return_data);
+        library\CommUtils::echoOrCallback($jsonData, $_GET);
+        } else {
+        $return_data = array("context" => array("id" => $data["rev_vis"], "query" => $data["vis_query"], "service" => $data["vis_title"]
+                                 , "timestamp" => $data["rev_timestamp"], "params" => $data["vis_params"]),
+                             "data" => $data["rev_data"]);
+         $jsonData = json_encode($return_data);
+         library\CommUtils::echoOrCallback($jsonData, $_GET);
+      }
       } else {
           $jsonData = $persistence->getLastVersion($vis_id);
           library\CommUtils::echoOrCallback($jsonData[0], $_GET);

--- a/server/services/searchTRIPLE.php
+++ b/server/services/searchTRIPLE.php
@@ -13,7 +13,7 @@ $precomputed_id = (isset($_POST["unique_id"]))?($_POST["unique_id"]):(null);
 $post_params = $_POST;
 
 $result = search("triple", $dirty_query
-                , $post_params, array("from", "to", "sorting")
+                , $post_params, array("from", "to", "sorting", "vis_type")
                 , ";", null, true, true, null, 3
                 , "area_uri", "subject", $precomputed_id, false
                 , "api");

--- a/server/workers/dataprocessing/src/headstart.py
+++ b/server/workers/dataprocessing/src/headstart.py
@@ -66,7 +66,7 @@ class Dataprocessing(object):
             sg_data = get_streamgraph_data(json.loads(metadata), params.get('top_n', 12))
             result = {}
             result["data"] = metadata
-            result["streamgraph"] = sg_data
+            result["streamgraph"] = json.dumps(sg_data)
             redis_store.set(k+"_output", json.dumps(result))
         else:
             result = self.create_map(params, input_data)

--- a/server/workers/dataprocessing/src/headstart.py
+++ b/server/workers/dataprocessing/src/headstart.py
@@ -61,10 +61,13 @@ class Dataprocessing(object):
         k, params, input_data = self.next_item()
         self.logger.debug(k)
         self.logger.debug(params)
-        result = self.create_map(params, input_data)
         if params.get('vis_type') == "timeline":
-            result = get_streamgraph_data(json.loads(result), params.get('top_n', 12))
-        redis_store.set(k+"_output", json.dumps(result))
+            metadata = json.loads(self.create_map(params, input_data))
+            sg_data = get_streamgraph_data(metadata, params.get('top_n', 12))
+            
+        else:
+            result = self.create_map(params, input_data)
+            redis_store.set(k+"_output", json.dumps(result))
 
 
 if __name__ == '__main__':

--- a/server/workers/dataprocessing/src/headstart.py
+++ b/server/workers/dataprocessing/src/headstart.py
@@ -3,11 +3,12 @@ import sys
 import copy
 import json
 import subprocess
-import asyncio
 from tempfile import NamedTemporaryFile
 import redis
 import pandas as pd
 import logging
+
+from streamgraph import get_streamgraph_data
 
 
 class Dataprocessing(object):
@@ -61,6 +62,8 @@ class Dataprocessing(object):
         self.logger.debug(k)
         self.logger.debug(params)
         result = self.create_map(params, input_data)
+        if params.get('vis_type') == "timeline":
+            result = get_streamgraph_data(result, params.get('top_n', 12))
         redis_store.set(k+"_output", json.dumps(result))
 
 

--- a/server/workers/dataprocessing/src/headstart.py
+++ b/server/workers/dataprocessing/src/headstart.py
@@ -63,7 +63,7 @@ class Dataprocessing(object):
         self.logger.debug(params)
         result = self.create_map(params, input_data)
         if params.get('vis_type') == "timeline":
-            result = get_streamgraph_data(result, params.get('top_n', 12))
+            result = get_streamgraph_data(json.loads(result), params.get('top_n', 12))
         redis_store.set(k+"_output", json.dumps(result))
 
 

--- a/server/workers/dataprocessing/src/headstart.py
+++ b/server/workers/dataprocessing/src/headstart.py
@@ -62,9 +62,12 @@ class Dataprocessing(object):
         self.logger.debug(k)
         self.logger.debug(params)
         if params.get('vis_type') == "timeline":
-            metadata = json.loads(self.create_map(params, input_data))
-            sg_data = get_streamgraph_data(metadata, params.get('top_n', 12))
-            
+            metadata = self.create_map(params, input_data)
+            sg_data = get_streamgraph_data(json.loads(metadata), params.get('top_n', 12))
+            result = {}
+            result["data"] = metadata
+            result["streamgraph"] = sg_data
+            redis_store.set(k+"_output", json.dumps(result))
         else:
             result = self.create_map(params, input_data)
             redis_store.set(k+"_output", json.dumps(result))

--- a/server/workers/dataprocessing/src/streamgraph.py
+++ b/server/workers/dataprocessing/src/streamgraph.py
@@ -1,0 +1,77 @@
+import pandas as pd
+
+
+def get_streamgraph_data(metadata, n=12):
+    df = pd.DataFrame.from_records(metadata)
+    df.year = pd.to_datetime(df.year)
+    df.year = df.year.map(lambda x: x.year)
+    df.subject = df.subject.map(lambda x: x.split("; "))
+    df["boundary_label"] = df.year.astype(int)
+    df = df.explode('subject')
+    counts = get_counts(df)
+    boundaries = get_boundaries(df)
+    data = pd.merge(counts, boundaries, on='year')
+    top_n = get_top_n(data, n)
+    data = data[data.subject.map(lambda x: x in top_n)].sort_values("year").reset_index(drop=True)
+    data = data[data.subject != ""]
+    sg_data = {}
+    sg_data["x"] = get_daterange(boundaries)
+    sg_data["subject"] = postprocess(boundaries, data)
+    return data
+
+
+def get_daterange(boundaries):
+    daterange = pd.date_range(start=min(boundaries.year),
+                              end=max(boundaries.year),
+                              freq='A')
+    if len(daterange) > 0:
+        return sorted(daterange.to_list())
+    else:
+        return sorted(pd.unique(boundaries.year).tolist())
+
+
+def get_stream_range(df):
+    stream_range = {
+        "min": min(df.year),
+        "max": max(df.year),
+        "range": max(df.year) - min(df.year)
+    }
+    return stream_range
+
+
+def get_counts(df):
+    counts = (df.groupby(["year", "subject"])
+                .agg({'subject': 'count', 'id': lambda x: ", ".join(x)}))
+    counts.rename({"subject": "counts"}, axis=1, inplace=True)
+    counts.reset_index(inplace=True)
+    return counts
+
+
+def get_boundaries(df):
+    boundaries = df[["boundary_label", "year"]].drop_duplicates()
+    return boundaries
+
+
+def get_top_n(data, n):
+    top_n = (data.groupby('subject')
+                 .agg({"counts": "sum"})
+                 .sort_values("counts", ascending=False)
+                 .head(n).index.to_list())
+    return top_n
+
+
+def postprocess(boundaries, data):
+    daterange = list(range(min(boundaries.year), max(boundaries.year)))
+    x = pd.DataFrame(daterange, columns=["year"])
+    temp = []
+    for item in pd.unique(data.subject):
+        tmp = (pd.merge(data[data.subject == item].drop("year", axis=1), x,
+                        left_on="boundary_label", right_on="year",
+                        how="right")
+                 .fillna({"counts": 0, "subject": item, "id": "NA"}))
+        y = tmp.counts.astype(int).to_list()
+        ids_overall = pd.unique(tmp[tmp.id != "NA"].id.map(lambda x: x.split(", ")).explode()).tolist()
+        ids_timestep = tmp.id.map(lambda x: x.split(", ")).tolist()
+        temp.append({"name": item, "y": y, "ids_overall": ids_overall, "ids_timestep": ids_timestep})
+    df = pd.DataFrame.from_records(temp)
+    return df.to_dict(orient="records")

--- a/server/workers/dataprocessing/src/streamgraph.py
+++ b/server/workers/dataprocessing/src/streamgraph.py
@@ -24,7 +24,7 @@ def get_streamgraph_data(metadata, n=12):
 
 
 def get_x_axis(daterange):
-    return [x.year for x in daterange]
+    return [str(x.year) for x in daterange]
 
 
 def get_daterange(boundaries):

--- a/server/workers/triple/src/search_triple.py
+++ b/server/workers/triple/src/search_triple.py
@@ -52,6 +52,12 @@ class TripleClient(object):
             sort.append("date:desc")
         return sort
 
+    def get_limit(self, parameters):
+        limit = parameters.get('limit', 100)
+        if parameters.get('vis_type') == "timeline":
+            limit = 1000
+        return limit
+
     @staticmethod
     def parse_query(query, fields):
         qq = {}
@@ -119,7 +125,7 @@ class TripleClient(object):
         res = self.es.search(
             index=index,
             body=body,
-            size=parameters.get('limit', 100),
+            size=self.get_limit(parameters),
             sort=sorting)
         # res = self.es.search(
         #     index=index,

--- a/server/workers/triple/src/search_triple.py
+++ b/server/workers/triple/src/search_triple.py
@@ -60,7 +60,7 @@ class TripleClient(object):
     def get_limit(self, parameters):
         limit = parameters.get('limit', 100)
         if parameters.get('vis_type') == "timeline":
-            limit = 1000
+            limit = 100
         return limit
 
     @staticmethod

--- a/vis/js/headstart.js
+++ b/vis/js/headstart.js
@@ -200,8 +200,9 @@ HeadstartFSM.prototype = {
       },
 
       search_repos: function(that, setupVis) {
-        let url = config.server_url + "services/getLatestRevision.php?vis_id=" + mediator.current_bubble.file 
-                + "&context=" + config.show_context + "&streamgraph=" + config.is_streamgraph;
+        let url = config.server_url + "services/getLatestRevision.php?vis_id=" + mediator.current_bubble.file
+                + "&context=" + config.show_context + "&streamgraph=" + config.is_streamgraph
+                + "&backend=" + config.backend;
         mediator.publish("get_data_from_files", url, 'json', setupVis);
       },
       


### PR DESCRIPTION
This PR implements streamgraph functionality in the backend, and enables it for the TRIPLE API.
* searchTRIPLE.php now uses vis_type for ID creation
* streamgraph data is now persisted after search, an no longer created at map loading stage (faster for user)
* the url call to getLatestRevision in headstart.js now takes the additional parameter "backend". legacy integrations should not be affected

The TRIPLE example has been adapted:
* search_triple.html has been renamed to search_triple.php for the rudimentary search box
* it now has an alternating checkbox for knowledge map and streamgraph
* it now takes a config.php, with an example config attached

It has been tested for BASE, PubMed, VIPER, and knowledge map and streamgraph examples for TRIPLE.