### PR TITLE
implement subject_orig field where missing

### DIFF
--- a/server/preprocessing/other-scripts/openaire.R
+++ b/server/preprocessing/other-scripts/openaire.R
@@ -114,6 +114,7 @@ get_return_values <- function(all_artifacts){
 }
 
 preprocess_data <- function(all_artifacts){
+  all_artifacts$subject_orig <- all_artifacts$subject
   all_artifacts$subject <- unlist(lapply(all_artifacts$subject, function(x) {gsub("\\[[A-Za-z \\.-]+\\]", "", x)})) # removes [ INFO.INFO-MA ] Computer Science [cs]/Multiagent Systems [cs.MA]
   all_artifacts$subject <- unlist(lapply(all_artifacts$subject, function(x) {gsub(" ?/", ";", x)}))
   all_artifacts$subject <- unlist(lapply(all_artifacts$subject, function(x) {gsub("\\:.*\\:\\:", "", x)})) # keeps only last part after :: ":Enginyeria de la telecomunicació::Processament del senyal::Reconeixement de formes [Àrees temàtiques de la UPC]"

--- a/server/workers/gsheets/src/search_gsheets.py
+++ b/server/workers/gsheets/src/search_gsheets.py
@@ -228,7 +228,8 @@ class GSheetsClient(object):
         metadata["year"] = df["Publication Date"]
         metadata["url"] = df.ID
         metadata["readers"] = 0
-        metadata["subject"] = df.Keywords
+        metadata["subject_orig"] = df.Keywords
+        metadata["subject"] = metadata["subject_orig"]
         metadata["oa_state"] = df.Access
         metadata["link"] = df["Link to PDF"].map(lambda x: x.replace("N/A", "") if isinstance(x, str) else "")
         metadata["relevance"] = df.index

--- a/server/workers/triple/src/search_triple.py
+++ b/server/workers/triple/src/search_triple.py
@@ -169,7 +169,8 @@ class TripleClient(object):
         metadata["year"] = df.datestamp.map(lambda x: x if isinstance(x, str) else "")
         metadata["url"] = df.url.map(lambda x: x[0] if isinstance(x, list) else "")
         metadata["readers"] = 0
-        metadata["subject"] = df.keyword.map(lambda x: "; ".join([self.clean_subject(s) for s in x]) if isinstance(x, list) else "")
+        metadata["subject_orig"] = df.keyword.map(lambda x: "; ".join([self.clean_subject(s) for s in x]) if isinstance(x, list) else "")
+        metadata["subject"] = metadata["subject_orig"]
         metadata["oa_state"] = 2
         metadata["link"] = ""
         metadata["relevance"] = df.index


### PR DESCRIPTION
This PR add "subject_orig" metadata field to map data delivered by the backend for the data integrations where that field has been missing so far.