### PR TITLE
fix for doaj source, query needed space between query & "AND"

### DIFF
--- a/server/preprocessing/other-scripts/doaj.R
+++ b/server/preprocessing/other-scripts/doaj.R
@@ -31,8 +31,6 @@ get_papers <- function(query, params, limit=100,
   year_to = params$to
   date_string = paste0("bibjson.year:[", params$from, " TO ", params$to , "]")
 
-  sortby_string =
-
   if (params$sorting == "most-recent") {
     sortby_string = "year:desc"
   }
@@ -40,7 +38,7 @@ get_papers <- function(query, params, limit=100,
   res = jaod_article_search(query=paste0(query
                                          , ' AND ', date_string
                                          #, ' AND index.language:"English"'
-                                         , 'AND _exists_:bibjson.abstract')
+                                         , ' AND _exists_:bibjson.abstract')
                             , sort=sortby_string
                             , pageSize=100)
 

--- a/server/preprocessing/other-scripts/test/doaj-test.R
+++ b/server/preprocessing/other-scripts/test/doaj-test.R
@@ -5,7 +5,6 @@ library(rstudioapi)
 options(warn=1)
 
 wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
-
 setwd(wd) #Don't forget to set your working directory
 
 query <- "marketing" #args[2]
@@ -13,27 +12,55 @@ service <- "doaj"
 params <- NULL
 params_file <- "params_doaj.json"
 
-source("../vis_layout.R")
-source('../doaj.R')
 source('../utils.R')
-
 DEBUG = FALSE
 
+if (DEBUG==TRUE){
+  setup_logging('DEBUG')
+} else {
+  setup_logging('INFO')
+}
+
+tslog <- getLogger('ts')
+
+source("../vis_layout.R")
+source('../doaj.R')
+
 MAX_CLUSTERS = 15
-ADDITIONAL_STOP_WORDS = "english"
 
 if(!is.null(params_file)) {
   params <- fromJSON(params_file)
 }
 
-#start.time <- Sys.time()
+ADDITIONAL_STOP_WORDS = "english"
 
-input_data = get_papers(query, params)
+#start.time <- Sys.time()
+failed <- list(params=params)
+tryCatch({
+  input_data = get_papers(query, params)
+}, error=function(err){
+  tslog$error(gsub("\n", " ", paste("Query failed", service, query, paste(params, collapse=" "), err, sep="||")))
+  failed$query <<- query
+  failed$query_reason <<- err$message
+})
 
 #end.time <- Sys.time()
 #time.taken <- end.time - start.time
 #time.taken
+tryCatch({
+output_json = vis_layout(input_data$text, input_data$metadata,
+                         service,
+                         max_clusters=MAX_CLUSTERS,
+                         lang="english",
+                         add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
+}, error=function(err){
+  tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
+  failed$query <<- query
+  failed$processing_reason <<- err$message
+})
 
-output_json = vis_layout(input_data$text, input_data$metadata, max_clusters=MAX_CLUSTERS, add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
+if (!exists('output_json')) {
+  output_json <- detect_error(failed)
+}
 
 print(output_json)


### PR DESCRIPTION
Addresses "DOAJ integration fails" item in trello. There wasn't a space before the second `AND` of the query so that it ended up as `marketing AND bibjson.year:[1809 TO 2017]AND _exists_:bibjson.abstract` which gave no results

Also, deleted a line of code (see line 34) that wasn't supposed to be there AFAICT. 