### PR TITLE
Add coverage and config import to jest tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ config.js
 .Rhistory
 .ipynb_checkpoints
 .Rprofile
+coverage/

--- a/package.json
+++ b/package.json
@@ -96,6 +96,10 @@
     "webpack-merge": "^4.2.2"
   },
   "jest": {
-    "collectCoverage": true
+    "moduleNameMapper": {
+      "^config$": "<rootDir>/vis/js/default-config.js"
+    },
+    "collectCoverage": true,
+    "coveragePathIgnorePatterns": ["/node_modules/", "<rootDir>/vis/js/default-config.js"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,5 +94,8 @@
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.11.0",
     "webpack-merge": "^4.2.2"
+  },
+  "jest": {
+    "collectCoverage": true
   }
 }

--- a/vis/test/example.test.js
+++ b/vis/test/example.test.js
@@ -3,7 +3,9 @@ import Adapter from 'enzyme-adapter-react-16';
 import { configure, shallow } from 'enzyme';
 import ExampleModernComponent from '../js/components/ExampleModernComponent';
 
+import config from "config";
+
 configure({adapter: new Adapter()});
 it('renders without crashing', () => {
-  shallow(<ExampleModernComponent />);
+  shallow(<ExampleModernComponent text={config.language} />);
 });


### PR DESCRIPTION
Adding the `collectCoverage` option to the jest settings to show code coverage. After each run, jest creates an html report and saves it into the `coverage/` directory, so I added this directory to the `.gitignore`.

Adding the config path to the jest settings - before that, files with config imported couldn't be tested. Changed the example test to show it works.