### PR TITLE
enable force update for gsheet integration

### DIFF
--- a/server/search_gsheets.docker
+++ b/server/search_gsheets.docker
@@ -8,8 +8,9 @@ RUN apk add build-base gcc
 WORKDIR /headstart
 COPY workers/gsheets/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY workers/gsheets/src/ ./
-COPY workers/gsheets/token.pickle ./
+COPY workers/gsheets/src/ ./gsheets/src
+COPY workers/run_gsheets.py .
+COPY workers/gsheets/token.pickle ./gsheets
 COPY workers/redis_config.json .
 
-ENTRYPOINT python search_gsheets.py
+ENTRYPOINT python run_gsheets.py

--- a/server/services/updateGSheetsMap.php
+++ b/server/services/updateGSheetsMap.php
@@ -14,19 +14,26 @@ if(php_sapi_name() == 'cli') {
     $shortopts = "";
     $longopts = array(
       "q:",
-      "sheet_id:"
+      "sheet_id:",
+      "last_update"
     );
     $options = getopt($shortopts, $longopts);
     $dirty_query = $options["q"];
     $sheet_id = $options["sheet_id"];
+    $last_update = $options["last_update"];
 } elseif(php_sapi_name() == 'apache2handler') {
     // Called from the apache2 webserver upon web request
     $dirty_query = library\CommUtils::getParameter($_GET, "q");
     $sheet_id = library\CommUtils::getParameter($_GET, "sheet_id");
+    $last_update = isset($_GET["gsheet_last_updated"]) ? library\CommUtils::getParameter($_GET, "gsheet_last_updated") : null;
 }
 
+$params = array("q" => $dirty_query, "sheet_id" => $sheet_id, "sheet_range" => "Resources!A1:AG200");
+if(isset($last_update)) {
+    $params["last_update"] = $last_update;
+}
 
-$result = search("gsheets", $dirty_query, array("q" => $dirty_query, "sheet_id" => $sheet_id, "sheet_range" => "Resources!A1:AG200")
+$result = search("gsheets", $dirty_query, $params
                     , array("sheet_id")
                     , ";", null, false, false, null, 3
                     , "area_uri", "subject", $sheet_id, false

--- a/server/workers/gsheets/src/search_gsheets.py
+++ b/server/workers/gsheets/src/search_gsheets.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import sys
 import json
 import time
@@ -79,34 +80,37 @@ def process_comments(row):
 
 class GSheetsClient(object):
 
-    def __init__(self):
+    def __init__(self, redis_store, loglevel="INFO"):
         # If modifying these scopes, delete the file token.pickle.
         self.SCOPES = ['https://www.googleapis.com/auth/spreadsheets.readonly',
                        'https://www.googleapis.com/auth/drive.metadata.readonly']
+        self.redis_store = redis_store
         self.register_services()
         self.last_updated = {}
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(os.environ["GSHEETS_LOGLEVEL"])
+        self.logger.setLevel(loglevel)
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(formatter)
-        handler.setLevel(os.environ["GSHEETS_LOGLEVEL"])
+        handler.setLevel(loglevel)
         self.logger.addHandler(handler)
         self.get_startPageToken()
 
     def authenticate(self):
         creds = None
-        if os.path.exists('token.pickle'):
-            with open('token.pickle', 'rb') as token:
+        tokenpath = os.path.join(pathlib.Path(__file__).parent.parent, "token.pickle")
+        credentialspath = os.path.join(pathlib.Path(__file__).parent.parent, "credentials.json")
+        if os.path.exists(tokenpath):
+            with open(tokenpath, 'rb') as token:
                 creds = pickle.load(token)
         if not creds or not creds.valid:
             if creds and creds.expired and creds.refresh_token:
                 creds.refresh(Request())
             else:
                 flow = InstalledAppFlow.from_client_secrets_file(
-                    'credentials.json', self.SCOPES)
+                    credentialspath, self.SCOPES)
                 creds = flow.run_local_server(port=0)
             # Save the credentials for the next run
-            with open('token.pickle', 'wb') as token:
+            with open(tokenpath, 'wb') as token:
                 pickle.dump(creds, token)
         return creds
 
@@ -121,7 +125,7 @@ class GSheetsClient(object):
         self.startPageToken = res.get('startPageToken')
 
     def get_currentPageToken(self, sheet_id):
-        pageToken = self.last_updated[sheet_id] if sheet_id in self.last_updated else self.startPageToken
+        pageToken = self.last_updated.get(sheet_id).get("pageToken") if sheet_id in self.last_updated else self.startPageToken
         return pageToken if pageToken is not None else self.startPageToken
 
     def get_changes(self, pageToken):
@@ -143,7 +147,7 @@ class GSheetsClient(object):
             if len(filtered_changes) != 0:
                 self.logger.debug(filtered_changes)
                 last_change = filtered_changes[-1]
-                self.last_updated[sheet_id] = res.get('newStartPageToken')
+                self.last_updated[sheet_id]["pageToken"] = res.get('newStartPageToken')
                 self.logger.debug(self.last_updated)
                 return last_change.get('time')
             else:
@@ -152,7 +156,7 @@ class GSheetsClient(object):
             return False
 
     def next_item(self):
-        queue, msg = redis_store.blpop("gsheets")
+        queue, msg = self.redis_store.blpop("gsheets")
         msg = json.loads(msg)
         k = msg.get('id')
         params = msg.get('params')
@@ -246,30 +250,42 @@ class GSheetsClient(object):
         input_data["text"] = text.to_json(orient='records')
         return input_data
 
+    def get_new_mapdata(self, sheet_id, sheet_range, params):
+        raw = self.get_sheet_content(sheet_id, sheet_range)
+        clean_df, errors, errors_df = self.validate_data(raw)
+        input_data = self.create_input_data(clean_df)
+        map_k = str(uuid.uuid4())
+        map_input = {}
+        map_input["id"] = map_k
+        map_input["input_data"] = input_data
+        map_input["params"] = params
+        self.redis_store.rpush("input_data", json.dumps(map_input))
+        result = get_key(self.redis_store, map_k)
+        result_df = self.post_process(clean_df, pd.DataFrame.from_records(json.loads(result)))
+        res = {}
+        res["data"] = result_df.to_json(orient="records")
+        res["errors"] = errors_df.to_dict(orient="records")
+        res["sheet_id"] = sheet_id
+        res["last_update"] = self.last_updated[sheet_id]["timestamp_utc"]
+        return res
+
     def update(self, params):
+        res = {"status": "No update required"}
         sheet_id = params.get('sheet_id')
         sheet_range = params.get('sheet_range')
-        last_update = self.update_required(sheet_id)
-        if last_update is not False:
-            raw = self.get_sheet_content(sheet_id, sheet_range)
-            clean_df, errors, errors_df = self.validate_data(raw)
-            input_data = self.create_input_data(clean_df)
-            map_k = str(uuid.uuid4())
-            map_input = {}
-            map_input["id"] = map_k
-            map_input["input_data"] = input_data
-            map_input["params"] = params
-            redis_store.rpush("input_data", json.dumps(map_input))
-            result = get_key(redis_store, map_k)
-            result_df = self.post_process(clean_df, pd.DataFrame.from_records(json.loads(result)))
-            res = {}
-            res["data"] = result_df.to_json(orient="records")
-            res["errors"] = errors_df.to_dict(orient="records")
-            res["sheet_id"] = sheet_id
-            d = parse(last_update)
-            res["last_update"] = d.strftime("%Y-%m-%d %H:%M:%S %Z")
-        else:
-            res = {"status": "No update required"}
+        last_known_update = params.get('last_update')
+        if not sheet_id in self.last_updated:
+            self.last_updated[sheet_id] = {}
+            last_change = self.files.get(fileId=sheet_id, fields='modifiedTime').execute().get('modifiedTime')
+            d = parse(last_change)
+            last_update_timestamp_utc = d.strftime("%Y-%m-%d %H:%M:%S %Z")
+            self.last_updated[sheet_id]["timestamp_utc"] = last_update_timestamp_utc
+        sheet_has_changed = self.sheet_has_changed(sheet_id)
+        if (last_known_update is not None and
+            last_known_update != self.last_updated[sheet_id]["timestamp_utc"]):
+            res = self.get_new_mapdata(sheet_id, sheet_range, params)
+        if sheet_has_changed is True:
+            res = self.get_new_mapdata(sheet_id, sheet_range, params)
         return res
 
     def run(self):
@@ -279,16 +295,7 @@ class GSheetsClient(object):
             self.logger.debug(params)
             try:
                 res = self.update(params)
-                redis_store.set(k+"_output", json.dumps(res))
+                self.redis_store.set(k+"_output", json.dumps(res))
             except Exception as e:
                 self.logger.error(e)
                 self.logger.error(params)
-
-
-if __name__ == '__main__':
-    with open("redis_config.json") as infile:
-        redis_config = json.load(infile)
-
-    redis_store = redis.StrictRedis(**redis_config)
-    gc = GSheetsClient()
-    gc.run()

--- a/server/workers/run_gsheets.py
+++ b/server/workers/run_gsheets.py
@@ -1,0 +1,13 @@
+import os
+import json
+import redis
+from gsheets.src.search_gsheets import GSheetsClient
+
+
+if __name__ == '__main__':
+    with open("redis_config.json") as infile:
+        redis_config = json.load(infile)
+
+    redis_store = redis.StrictRedis(**redis_config)
+    gc = GSheetsClient(redis_store, os.environ.get("GSHEETS_LOGLEVEL", "INFO"))
+    gc.run()

--- a/server/workers/services/src/apis/gsheets.py
+++ b/server/workers/services/src/apis/gsheets.py
@@ -25,7 +25,9 @@ search_query = gsheets_ns.model("SearchQuery",
                                                               description="Sheet name and data range to retrieve from",
                                                               required=True),
                                  "q": fields.String(example='covid19',
-                                                            description='hardcoded vis name')})
+                                                            description='hardcoded vis name'),
+                                 "last_update": fields.String(example='2020-07-20 11:47:50 UTC',
+                                                              description='timestamp of last known GSheets edit')})
 
 
 @gsheets_ns.route('/search')


### PR DESCRIPTION
This PR enables requesting new map data by comparing a "last_update" parameter with the last known change in the GSheet. The server responds with new mapdata when these two timezone-strings don't match.

They can be call by either a GET request to updateGSheetsMap with a "last_update" parameter, or a command line call with `--last_update`