### PR TITLE
Refactoring 01 (MVP): popover fix

### DIFF
--- a/vis/js/components/ContextLine.js
+++ b/vis/js/components/ContextLine.js
@@ -35,57 +35,55 @@ class ContextLine extends React.Component {
     return (
       // TODO this <p> can be moved into the template when whole MVP is refactored
       // then a different container for the popovers can be chosen
-      <p id="context" style={{ position: "relative" }}>
-        <ContextLineTemplate>
-          {params.showAuthor && (
-            <Author
-              bioLabel={localization.bio_link}
-              livingDates={params.author.livingDates}
-              link={"https://d-nb.info/gnd/" + params.author.id}
-            />
-          )}
-          <NumArticles
-            articlesCount={params.articlesCount}
-            openAccessArticlesCount={params.openAccessCount}
-            articlesCountLabel={localization.articles_label}
-          >
-            {this.renderModifier()}
-          </NumArticles>
-          {defined(params.dataSource) && (
-            <DataSource
-              value={params.dataSource}
-              label={localization.source_label}
-            />
-          )}
-          {defined(params.timespan) && <Timespan>{params.timespan}</Timespan>}
-          {this.renderDocTypes()}
-          {defined(params.paperCount) && (
-            <PaperCount
-              value={params.paperCount}
-              label={localization.paper_count_label}
-            />
-          )}
-          {defined(params.datasetCount) && (
-            <DatasetCount
-              value={params.datasetCount}
-              label={localization.dataset_count_label}
-            />
-          )}
-          {defined(params.funder) && <Funder>{params.funder}</Funder>}
-          {defined(params.projectRuntime) && (
-            <ProjectRuntime>{params.projectRuntime}</ProjectRuntime>
-          )}
-          {defined(params.searchLanguage) && (
-            <SearchLang>{params.searchLanguage}</SearchLang>
-          )}
-          {defined(params.timestamp) && (
-            <Timestamp
-              value={params.timestamp}
-              label={localization.timestamp_label}
-            />
-          )}
-        </ContextLineTemplate>
-      </p>
+      <ContextLineTemplate>
+        {params.showAuthor && (
+          <Author
+            bioLabel={localization.bio_link}
+            livingDates={params.author.livingDates}
+            link={"https://d-nb.info/gnd/" + params.author.id}
+          />
+        )}
+        <NumArticles
+          articlesCount={params.articlesCount}
+          openAccessArticlesCount={params.openAccessCount}
+          articlesCountLabel={localization.articles_label}
+        >
+          {this.renderModifier()}
+        </NumArticles>
+        {defined(params.dataSource) && (
+          <DataSource
+            value={params.dataSource}
+            label={localization.source_label}
+          />
+        )}
+        {defined(params.timespan) && <Timespan>{params.timespan}</Timespan>}
+        {this.renderDocTypes()}
+        {defined(params.paperCount) && (
+          <PaperCount
+            value={params.paperCount}
+            label={localization.paper_count_label}
+          />
+        )}
+        {defined(params.datasetCount) && (
+          <DatasetCount
+            value={params.datasetCount}
+            label={localization.dataset_count_label}
+          />
+        )}
+        {defined(params.funder) && <Funder>{params.funder}</Funder>}
+        {defined(params.projectRuntime) && (
+          <ProjectRuntime>{params.projectRuntime}</ProjectRuntime>
+        )}
+        {defined(params.searchLanguage) && (
+          <SearchLang>{params.searchLanguage}</SearchLang>
+        )}
+        {defined(params.timestamp) && (
+          <Timestamp
+            value={params.timestamp}
+            label={localization.timestamp_label}
+          />
+        )}
+      </ContextLineTemplate>
     );
   }
 
@@ -93,6 +91,7 @@ class ContextLine extends React.Component {
     const {
       params: { modifier, showModifierPopover },
       localization,
+      popoverContainer,
     } = this.props;
 
     let label = "";
@@ -110,7 +109,7 @@ class ContextLine extends React.Component {
         <>
           <HoverPopover
             id="modifier-popover"
-            container={this}
+            container={popoverContainer}
             content={localization.most_relevant_tooltip}
           >
             <span id="modifier" className="modifier context_moreinfo">
@@ -134,6 +133,7 @@ class ContextLine extends React.Component {
     const {
       params: { documentTypes },
       localization,
+      popoverContainer,
     } = this.props;
 
     if (!documentTypes || documentTypes.length === 0) {
@@ -156,7 +156,7 @@ class ContextLine extends React.Component {
         <span id="document_types" className="context_item">
           <HoverPopover
             id="doctypes-popover"
-            container={this}
+            container={popoverContainer}
             content={
               <>
                 {localization.documenttypes_tooltip}

--- a/vis/js/components/HoverPopover.js
+++ b/vis/js/components/HoverPopover.js
@@ -7,7 +7,7 @@ const HoverPopover = ({
   content,
   children,
   container, // = null
-  placement = "bottom",
+  placement = "right",
 }) => {
   const popover = <Popover id={id}>{content}</Popover>;
 

--- a/vis/js/components/SubdisciplineTitle.js
+++ b/vis/js/components/SubdisciplineTitle.js
@@ -4,14 +4,16 @@ import Heading from "./Heading";
 import Backlink from "./Backlink";
 import ContextLine from "./ContextLine";
 
-export const SubdisciplineTitle = () => {
-  return (
-    <div id="subdiscipline_title">
-      <Heading />
-      <Backlink />
-      <ContextLine />
-    </div>
-  );
-};
+class SubdisciplineTitle extends React.Component {
+  render() {
+    return (
+      <div id="subdiscipline_title" style={{position: "relative"}}>
+        <Heading />
+        <Backlink />
+        <ContextLine popoverContainer={this} />
+      </div>
+    );
+  }
+}
 
 export default SubdisciplineTitle;

--- a/vis/js/templates/ContextLine.jsx
+++ b/vis/js/templates/ContextLine.jsx
@@ -5,8 +5,7 @@ import React from "react";
 const ContextLine = ({ children }) => {
   return (
     // html template starts here
-    // TODO <p id="context"> will move to here after the whole MVP is finished
-    <>{children}</>
+    <p id="context">{children}</p>
     // html template ends here
   );
 };

--- a/vis/test/component/contextline.test.js
+++ b/vis/test/component/contextline.test.js
@@ -4,6 +4,8 @@ import { act } from "react-dom/test-utils";
 
 import configureStore from "redux-mock-store";
 
+import { Provider } from "react-redux";
+
 import ContextLine from "../../js/components/ContextLine";
 
 const mockStore = configureStore([]);
@@ -578,15 +580,6 @@ describe("Context line component", () => {
     });
 
     it("shows a popover if hovered on more document types", () => {
-      // TODO suppressed the error saying <div> cannot be a descendant of <p>
-      global.console = {
-        log: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-        info: console.info,
-        debug: console.debug,
-      };
-
       const DOC_TYPES = ["custom document type", "another document type"];
 
       const storeObject = setup();
@@ -595,7 +588,12 @@ describe("Context line component", () => {
       const store = mockStore(storeObject);
 
       act(() => {
-        render(<ContextLine store={store} />, container);
+        render(
+          <Provider store={store}>
+            <MockContextLineContainer />
+          </Provider>,
+          container
+        );
       });
 
       const select = document.querySelector("#document_types>span");
@@ -618,3 +616,13 @@ describe("Context line component", () => {
     });
   });
 });
+
+class MockContextLineContainer extends React.Component {
+  render() {
+    return (
+      <div id="subdiscipline_title" style={{ position: "relative" }}>
+        <ContextLine popoverContainer={this} />
+      </div>
+    );
+  }
+}

--- a/vis/test/snapshot/__snapshots__/contextline.test.js.snap
+++ b/vis/test/snapshot/__snapshots__/contextline.test.js.snap
@@ -3,11 +3,6 @@
 exports[`Context line component snapshot matches a covis snapshot 1`] = `
 <p
   id="context"
-  style={
-    Object {
-      "position": "relative",
-    }
-  }
 >
   <span
     className="context_item"
@@ -51,11 +46,6 @@ exports[`Context line component snapshot matches a covis snapshot 1`] = `
 exports[`Context line component snapshot matches a linkedcat authorview snapshot 1`] = `
 <p
   id="context"
-  style={
-    Object {
-      "position": "relative",
-    }
-  }
 >
   <span
     className="context_item"
@@ -106,11 +96,6 @@ exports[`Context line component snapshot matches a linkedcat authorview snapshot
 exports[`Context line component snapshot matches a linkedcat keywordview snapshot 1`] = `
 <p
   id="context"
-  style={
-    Object {
-      "position": "relative",
-    }
-  }
 >
   <span
     className="context_item"
@@ -166,11 +151,6 @@ exports[`Context line component snapshot matches a linkedcat keywordview snapsho
 exports[`Context line component snapshot matches a project website snapshot 1`] = `
 <p
   id="context"
-  style={
-    Object {
-      "position": "relative",
-    }
-  }
 >
   <span
     className="context_item"
@@ -225,11 +205,6 @@ exports[`Context line component snapshot matches a project website snapshot 1`] 
 exports[`Context line component snapshot matches a viper snapshot 1`] = `
 <p
   id="context"
-  style={
-    Object {
-      "position": "relative",
-    }
-  }
 >
   <span
     className="context_item"


### PR DESCRIPTION
This PR introduces the popover fix:

- There was a console warning saying the &lt;div&gt; cannot be a descendant of &lt;p&gt;, so I fixed it by moving the popover into a different container. 
- Another issue was that the popovers were originally displayed at right, but after the first refactoring, I had to place them at the bottom. Now they're back at the right side.