### PR TITLE
Pubmed error reason

### DIFF
--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -67,7 +67,7 @@ output_json = vis_layout(input_data$text, input_data$metadata,
 })
 
 if (!exists('output_json')) {
-  output_json <- detect_error(failed)
+  output_json <- detect_error(failed, service)
 }
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/base-test.R
+++ b/server/preprocessing/other-scripts/test/base-test.R
@@ -54,17 +54,19 @@ tryCatch({
 #end.time <- Sys.time()
 #time.taken <- end.time - start.time
 #time.taken
-tryCatch({
-output_json = vis_layout(input_data$text, input_data$metadata,
-                         service,
-                         max_clusters=MAX_CLUSTERS,
-                         lang=LANGUAGE$name,
-                         add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
-}, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
-  failed$query <<- query
-  failed$processing_reason <<- err$message
-})
+if(exists('input_data')) {
+  tryCatch({
+  output_json = vis_layout(input_data$text, input_data$metadata,
+                           service,
+                           max_clusters=MAX_CLUSTERS,
+                           lang=LANGUAGE$name,
+                           add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=100)
+  }, error=function(err){
+    tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
+    failed$query <<- query
+    failed$processing_reason <<- err$message
+  })
+}
 
 if (!exists('output_json')) {
   output_json <- detect_error(failed, service)

--- a/server/preprocessing/other-scripts/test/params_pubmed.json
+++ b/server/preprocessing/other-scripts/test/params_pubmed.json
@@ -91,4 +91,4 @@
   "validation study",
   "video audio media",
   "webcast"
-  ],"from":"1809-01-01","to":"2017-12-04","sorting":"most-recent"}
+  ],"from":"1809-01-01","to":"2020-09-21","sorting":"most-relevant"}

--- a/server/preprocessing/other-scripts/test/pubmed-test.R
+++ b/server/preprocessing/other-scripts/test/pubmed-test.R
@@ -54,17 +54,19 @@ tryCatch({
 #end.time <- Sys.time()
 #time.taken <- end.time - start.time
 #time.taken
-tryCatch({
-  output_json = vis_layout(input_data$text, input_data$metadata,
-                           service,
-                           max_clusters=MAX_CLUSTERS,
-                           lang=LANGUAGE$name,
-                           add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
-}, error=function(err){
-  tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
-  failed$query <<- query
-  failed$processing_reason <<- err$message
-})
+if(exists('input_data')) {
+  tryCatch({
+    output_json = vis_layout(input_data$text, input_data$metadata,
+                             service,
+                             max_clusters=MAX_CLUSTERS,
+                             lang=LANGUAGE$name,
+                             add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE)
+  }, error=function(err){
+    tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
+    failed$query <<- query
+    failed$processing_reason <<- err$message
+  })
+}
 
 if (!exists('output_json')) {
   output_json <- detect_error(failed, service)

--- a/server/preprocessing/other-scripts/test/pubmed-test.R
+++ b/server/preprocessing/other-scripts/test/pubmed-test.R
@@ -7,7 +7,7 @@ options(warn=1)
 wd <- dirname(rstudioapi::getActiveDocumentContext()$path)
 setwd(wd) #Don't forget to set your working directory
 
-query <- "russian" #args[2]
+query <- "sustainable development goals" #args[2]
 service <- "pubmed"
 params <- NULL
 params_file <- "params_pubmed.json"
@@ -67,7 +67,7 @@ tryCatch({
 })
 
 if (!exists('output_json')) {
-  output_json <- detect_error(failed)
+  output_json <- detect_error(failed, service)
 }
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/test-openaire.R
+++ b/server/preprocessing/other-scripts/test/test-openaire.R
@@ -54,24 +54,24 @@ tryCatch({
   failed$query_reason <<- err$message
 })
 
-tryCatch({
-output_json = vis_layout(input_data$text, input_data$metadata,
-                         service,
-                         max_clusters=MAX_CLUSTERS,
-                         lang=LANGUAGE$name,
-                         add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=-1)
-}, error=function(err){
-tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
-  failed$query <<- query
-  failed$processing_reason <<- err$message
-})
-
-if (service=='openaire' && exists('output_json')) {
-  output_json = enrich_output_json(output_json)
+if(exists('input_data')) {
+  tryCatch({
+  output_json = vis_layout(input_data$text, input_data$metadata,
+                           service,
+                           max_clusters=MAX_CLUSTERS,
+                           lang=LANGUAGE$name,
+                           add_stop_words=ADDITIONAL_STOP_WORDS, testing=TRUE, list_size=-1)
+  }, error=function(err){
+  tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
+    failed$query <<- query
+    failed$processing_reason <<- err$message
+  })
 }
 
 if (!exists('output_json')) {
   output_json <- detect_error(failed, service)
+} else if (service=='openaire' && exists('output_json')) {
+  output_json <- enrich_output_json(output_json)
 }
 
 print(output_json)

--- a/server/preprocessing/other-scripts/test/test-openaire.R
+++ b/server/preprocessing/other-scripts/test/test-openaire.R
@@ -71,7 +71,7 @@ if (service=='openaire' && exists('output_json')) {
 }
 
 if (!exists('output_json')) {
-  output_json <- detect_error(failed)
+  output_json <- detect_error(failed, service)
 }
 
 print(output_json)

--- a/server/preprocessing/other-scripts/text_similarity.R
+++ b/server/preprocessing/other-scripts/text_similarity.R
@@ -102,27 +102,26 @@ tryCatch({
   failed$query_reason <<- err$message
 })
 
-
-print("got the input")
-tryCatch({
-  output_json = vis_layout(input_data$text, input_data$metadata,
-                           service,
-                           max_clusters=MAX_CLUSTERS, add_stop_words=ADDITIONAL_STOP_WORDS,
-                           lang=LANGUAGE$name,
-                           taxonomy_separator=taxonomy_separator, list_size = list_size,
-                           vis_type=vis_type)
-}, error=function(err){
- tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
- failed$query <<- query
- failed$processing_reason <<- err$message
-})
-
-if (service=='openaire' && exists('output_json')) {
-  output_json = enrich_output_json(output_json)
+if(exists('input_data')) {
+  print("got the input")
+  tryCatch({
+    output_json = vis_layout(input_data$text, input_data$metadata,
+                             service,
+                             max_clusters=MAX_CLUSTERS, add_stop_words=ADDITIONAL_STOP_WORDS,
+                             lang=LANGUAGE$name,
+                             taxonomy_separator=taxonomy_separator, list_size = list_size,
+                             vis_type=vis_type)
+  }, error=function(err){
+   tslog$error(gsub("\n", " ", paste("Processing failed", query, paste(params, collapse=" "), err, sep="||")))
+   failed$query <<- query
+   failed$processing_reason <<- err$message
+  })
 }
 
 if (!exists('output_json')) {
   output_json <- detect_error(failed, service)
+} else if (service=='openaire' && exists('output_json')) {
+  output_json <- enrich_output_json(output_json)
 }
 
 print(output_json)

--- a/server/preprocessing/other-scripts/text_similarity.R
+++ b/server/preprocessing/other-scripts/text_similarity.R
@@ -122,7 +122,7 @@ if (service=='openaire' && exists('output_json')) {
 }
 
 if (!exists('output_json')) {
-  output_json <- detect_error(failed)
+  output_json <- detect_error(failed, service)
 }
 
 print(output_json)

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -95,34 +95,26 @@ detect_error <- function(failed, service) {
     # then return them as json list
     if (startsWith(failed$query_reason, "HTTP failure: 502, bad gateway")){
         reason <- c(reason, 'API error: requested metadata size')
-      }
-    output$reason <- reason
-    output$status <- 'error'
-    return(toJSON(output, auto_unbox = TRUE))
-  }
-  if (!is.null(failed$processing_reason)) {
-    if (failed$processing_reason == "No input data found.") {
-      # first identify criteria
-      if (length(unlist(strsplit(failed$query, " "))) < 4) {
-        reason <- c(reason, 'typo', 'too specific')
       } else {
-        reason <- c(reason, 'query length', 'too specific')
+        # if not one of the known data source API errors:
+        # apply query error detection heuristics
+        if (length(unlist(strsplit(failed$query, " "))) < 4) {
+          reason <- c(reason, 'typo', 'too specific')
+        } else {
+          reason <- c(reason, 'query length', 'too specific')
+        }
+        if (!is.null(failed$params$to) &&
+            !is.null(failed$params$from) &&
+            difftime(failed$params$to, failed$params$from) <= 60) {
+          reason <- c(reason, 'timeframe too short')
       }
-      if (!is.null(failed$params$to) &&
-          !is.null(failed$params$from) &&
-          difftime(failed$params$to, failed$params$from) <= 60) {
-        reason <- c(reason, 'timeframe too short')
-      }
-      # then return them as json list
-      output$reason <- reason
-      output$status <- 'error'
-      return(toJSON(output, auto_unbox = TRUE))
-    } else {
-      reason <- c(reason, 'unexpected data processing error')
-      # then return them as json list
-      output$reason <- reason
-      output$status <- 'error'
-      return(toJSON(output, auto_unbox = TRUE))
     }
   }
+  if (length(reason) == 0) {
+      reason <- c(reason, 'unexpected data processing error')
+  }
+  # then return them as json list
+  output$reason <- reason
+  output$status <- 'error'
+  return(toJSON(output, auto_unbox = TRUE))
 }

--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -93,7 +93,7 @@ detect_error <- function(failed, service) {
   if (!is.null(failed$query_reason)) {
     # map response to individual error codes/messages
     # then return them as json list
-    if (startsWith(failed$query_reason, "HTTP failure: 502, bad gateway")){
+    if (service == 'pubmed' && startsWith(failed$query_reason, "HTTP failure: 502, bad gateway")){
         reason <- c(reason, 'API error: requested metadata size')
       } else {
         # if not one of the known data source API errors:

--- a/server/preprocessing/other-scripts/vis_layout.R
+++ b/server/preprocessing/other-scripts/vis_layout.R
@@ -30,10 +30,6 @@ vis_layout <- function(text, metadata, service,
   TESTING <<- testing # makes testing param a global variable
   start.time <- Sys.time()
 
-  if(!exists('input_data')){
-    stop("No input data found.")
-  }
-
   tryCatch({
    if(!isTRUE(testing)) {
      source('preprocess.R')


### PR DESCRIPTION
This PR improves error handling:

* errors are now more cleanly separated between data source/search errors and backend data processing errors: data processing errors are now no longer masked by typo/too specific and for now have a generic reason: 'unexpected data processing error'
* a specific error reason for 502 Bad Gateway errors on PubMed has been added: 'API error: requested metadata size'
* other API errors are for now masked by typo/too specific error, because the error handling in R is clumsy.