### PR TITLE
changes to base and pubmed get_papers methods to use retry

### DIFF
--- a/server/preprocessing/other-scripts/base.R
+++ b/server/preprocessing/other-scripts/base.R
@@ -11,6 +11,9 @@ library(rbace)
 #    * article_types: in the form of an array of identifiers of article types
 #    * sorting: can be one of "most-relevant" and "most-recent"
 # * limit: number of search results to return
+# * retry_opts: BASE retry options, see `?rbace::bs_retry_options` for documentation.
+#  `?httr::RETRY` has more detailed explanation of the options. default values are used if
+#   none are supplied.
 #
 # It is expected that get_papers returns a list containing two data frames named "text" and "metadata"
 #
@@ -34,7 +37,8 @@ blog <- getLogger('api.base')
 
 
 get_papers <- function(query, params, limit=100,
-                       fields="title,id,counter_total_month,abstract,journal,publication_date,author,subject,article_type") {
+                       fields="title,id,counter_total_month,abstract,journal,publication_date,author,subject,article_type",
+                       retry_opts=rbace::bs_retry_options()) {
 
   blog$info(paste("Search:", query))
   start.time <- Sys.time()
@@ -81,7 +85,8 @@ get_papers <- function(query, params, limit=100,
   (res_raw <- bs_search(hits=limit
                         , query = base_query
                         , fields = "dcdocid,dctitle,dcdescription,dcsource,dcdate,dcsubject,dccreator,dclink,dcoa,dcidentifier,dcrelation"
-                        , sortby = sortby_string))
+                        , sortby = sortby_string
+                        , retry = retry_opts))
   res <- res_raw$docs
   if (nrow(res)==0){
     stop(paste("No results retrieved."))


### PR DESCRIPTION
- each fxn gains a new parameter `retry_opts`
- the `retry_opts` parameter accepts a call to either the `bs_retry_options` or `entrez_retry_options` function from each respective package
- the retry options is a named list and gets passed to either rentrez or rbace to configure retry http settings
- defaults are used for retry options, but can be set by the user on each `get_papers` function call

fix #465 