### PR TITLE
phrase too long error

### DIFF
--- a/server/preprocessing/other-scripts/utils.R
+++ b/server/preprocessing/other-scripts/utils.R
@@ -89,6 +89,7 @@ get_service_lang <- function(lang_id, valid_langs, service) {
 detect_error <- function(failed, service) {
   output <- list()
   reason <- list()
+  phrasepattern <- '"(.*?)"'
   # branch off between API errors and our backend errors
   if (!is.null(failed$query_reason)) {
     # map response to individual error codes/messages
@@ -96,9 +97,13 @@ detect_error <- function(failed, service) {
     if (service == 'pubmed' && startsWith(failed$query_reason, "HTTP failure: 502, bad gateway")){
         reason <- c(reason, 'API error: requested metadata size')
       } else {
+        result <- regmatches(failed$query, regexec(phrasepattern, failed$query))
         # if not one of the known data source API errors:
         # apply query error detection heuristics
-        if (length(unlist(strsplit(failed$query, " "))) < 4) {
+        if (!identical(result[[1]], character(0)) &&
+            length(unlist(strsplit(result[[1]][2], " "))) > 4) {
+          reason <- c(reason, 'phrase too long')
+        } else if (length(unlist(strsplit(failed$query, " "))) < 4) {
           reason <- c(reason, 'typo', 'too specific')
         } else {
           reason <- c(reason, 'query length', 'too specific')

--- a/server/workers/triple/src/search_triple.py
+++ b/server/workers/triple/src/search_triple.py
@@ -81,7 +81,10 @@ class TripleClient(object):
 
     @staticmethod
     def parse_query(query, fields):
-        q = Q("multi_match", query=query, fields=fields)
+        if '"' in query:
+            q = Q("multi_match", query=query, fields=fields, type="phrase")
+        else:
+            q = Q("multi_match", query=query, fields=fields)
         return q
 
     def build_body(self, parameters):


### PR DESCRIPTION
This PR adds simple phrase search to the TRIPLE integration and adds a "phrase too long" error if a search that includes a phrase "longer than four words" returns no results.