### PR TITLE
Refactoring (List): toggle

### DIFF
--- a/vis/js/actions/index.js
+++ b/vis/js/actions/index.js
@@ -39,6 +39,10 @@ export const toggleList = () => ({
   type: "TOGGLE_LIST",
 });
 
+export const showList = () => ({
+  type: "SHOW_LIST",
+});
+
 // TODO refactor when possible to a non-setter action (or no action at all)
 export const setItemsCount = (count) => ({
   type: "SET_ITEMS_COUNT",

--- a/vis/js/actions/index.js
+++ b/vis/js/actions/index.js
@@ -34,3 +34,13 @@ export const changeFile = (fileIndex) => ({
   type: "FILE_CLICKED",
   fileIndex,
 });
+
+export const toggleList = () => ({
+  type: "TOGGLE_LIST",
+});
+
+// TODO refactor when possible to a non-setter action (or no action at all)
+export const setItemsCount = (count) => ({
+  type: "SET_ITEMS_COUNT",
+  count,
+});

--- a/vis/js/components/ListToggle.js
+++ b/vis/js/components/ListToggle.js
@@ -1,0 +1,25 @@
+import { connect } from "react-redux";
+
+import ListToggleTemplate from "../templates/ListToggle";
+import { toggleList } from "../actions";
+
+// no logic required
+
+const mapStateToProps = (state) => ({
+  toggleLabel: state.list.show
+    ? state.localization.hide_list
+    : state.localization.show_list,
+  // TODO derive this from the data
+  docsNumber: state.list.docsNumber,
+  docsNumberLabel: state.localization.items,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  onClick: () => {
+    // TODO remove warn
+    console.warn("*** React element 'List' click event triggered ***");
+    dispatch(toggleList());
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ListToggleTemplate);

--- a/vis/js/intermediate.js
+++ b/vis/js/intermediate.js
@@ -9,12 +9,14 @@ import {
   zoomInFromMediator,
   zoomOutFromMediator,
   initializeStore,
+  setItemsCount,
 } from "./actions";
 
 import { STREAMGRAPH_MODE } from "./reducers/chartType";
 
 import SubdisciplineTitle from "./components/SubdisciplineTitle";
 import AuthorImage from "./components/AuthorImage";
+import ListToggle from "./components/ListToggle";
 
 /**
  * Class to sit between the "old" mediator and the
@@ -26,7 +28,8 @@ class Intermediate {
   constructor(
     modern_frontend_enabled,
     knowledgeMapZoomOutCallback,
-    streamgraphZoomOutCallback
+    streamgraphZoomOutCallback,
+    listToggleCallback,
   ) {
     this.modern_frontend_enabled = modern_frontend_enabled;
     this.store = createStore(
@@ -36,7 +39,8 @@ class Intermediate {
           knowledgeMapZoomOutCallback,
           streamgraphZoomOutCallback
         ),
-        createFileChangeMiddleware()
+        createFileChangeMiddleware(),
+        createListToggleMiddleware(listToggleCallback)
       )
     );
   }
@@ -53,10 +57,24 @@ class Intermediate {
       </Provider>,
       document.getElementById("mvp_container")
     );
+  }
 
-    //if (this.modern_frontend_enabled) {
-    //  console.warn("*** FRONTEND FLAG ENABLED - new React elements rendered ***");
-    //}
+  /**
+   * List cannot be rendered with the initial components (heading etc.),
+   * so it has its own separate function.
+   */
+  renderList() {
+    if (this.modern_frontend_enabled) {
+      console.warn(
+        "*** FRONTEND FLAG ENABLED - new React elements rendered ***"
+      );
+      ReactDOM.render(
+        <Provider store={this.store}>
+          <ListToggle />
+        </Provider>,
+        document.getElementById("show_hide_button")
+      );
+    }
   }
 
   zoomIn(selectedAreaData) {
@@ -66,6 +84,22 @@ class Intermediate {
   zoomOut() {
     this.store.dispatch(zoomOutFromMediator());
   }
+
+  changeItemsCount(count) {
+    // TODO refactor when possible to a non-setter action (or no action at all)
+    this.store.dispatch(setItemsCount(count));
+  }
+}
+
+function createListToggleMiddleware(listToggleCallback) {
+  return function () {
+    return (next) => (action) => {
+      if (action.type == "TOGGLE_LIST") {
+        listToggleCallback();
+      }
+      return next(action);
+    };
+  };
 }
 
 function createZoomOutMiddleware(

--- a/vis/js/intermediate.js
+++ b/vis/js/intermediate.js
@@ -10,6 +10,7 @@ import {
   zoomOutFromMediator,
   initializeStore,
   setItemsCount,
+  showList,
 } from "./actions";
 
 import { STREAMGRAPH_MODE } from "./reducers/chartType";
@@ -88,6 +89,10 @@ class Intermediate {
   changeItemsCount(count) {
     // TODO refactor when possible to a non-setter action (or no action at all)
     this.store.dispatch(setItemsCount(count));
+  }
+
+  showList() {
+    this.store.dispatch(showList());
   }
 }
 

--- a/vis/js/list.js
+++ b/vis/js/list.js
@@ -81,11 +81,13 @@ export const list = StateMachine.create({
             d3.select("#papers_list").style("display", "block");
             d3.select("#left_arrow").text("\u25B2");
             d3.select("#right_arrow").text("\u25B2");
-            d3.select("#show_hide_label").html(showHideLabel({
-                show_or_hide_list: config.localization[config.language].hide_list,
-                items: config.localization[config.language].items,
-                item_count: this.list_item_count,
-            }));
+            if (!mediator.modern_frontend_enabled) {
+                d3.select("#show_hide_label").html(showHideLabel({
+                    show_or_hide_list: config.localization[config.language].hide_list,
+                    items: config.localization[config.language].items,
+                    item_count: this.list_item_count,
+                }));
+            }
             this.fit_list_height();
             list.count_visible_items_to_header();
         },
@@ -95,11 +97,13 @@ export const list = StateMachine.create({
             d3.select("#papers_list").style("display", "none");
             d3.select("#left_arrow").text("\u25BC");
             d3.select("#right_arrow").text("\u25BC");
-            d3.select("#show_hide_label").html(showHideLabel({
-                show_or_hide_list: config.localization[config.language].show_list,
-                items: config.localization[config.language].items,
-                item_count: this.list_item_count,
-            }));
+            if (!mediator.modern_frontend_enabled) {
+                d3.select("#show_hide_label").html(showHideLabel({
+                    show_or_hide_list: config.localization[config.language].show_list,
+                    items: config.localization[config.language].items,
+                    item_count: this.list_item_count,
+                }));
+            }
             list.count_visible_items_to_header();
         },
 
@@ -138,6 +142,7 @@ list.drawList = function() {
         items: config.localization[config.language].items,
         dropdown: config.sort_menu_dropdown,
         sort_by_label: config.localization[config.language].sort_by_label,
+        modern_frontend_enabled: mediator.modern_frontend_enabled,
     });
     $("#list_explorer").append(list_explorer);
     
@@ -231,8 +236,7 @@ list.count_visible_items_to_header = function() {
             count++
         }
     })
-    $('#list_item_count').text(count)
-
+    mediator.publish("list_item_count_change", count);
 }
 
 list.fit_list_height = function() {
@@ -351,16 +355,18 @@ list.addFilterOptionDropdownEntry = function (filter_option, first_item) {
 }
 
 list.initListMouseListeners = function() {
-    $("#show_hide_button")
-        .on("mouseover", function() {
-            $("#show_hide_button").addClass("hover");
-        })
-        .on("mouseout", function() {
-            $("#show_hide_button").removeClass("hover");
-        })
-        .on("click", function() {
-            mediator.publish("list_toggle");
-        });
+    if (!mediator.modern_frontend_enabled) {
+        $("#show_hide_button")
+            .on("mouseover", function() {
+                $("#show_hide_button").addClass("hover");
+            })
+            .on("mouseout", function() {
+                $("#show_hide_button").removeClass("hover");
+            })
+            .on("click", function() {
+                mediator.publish("list_toggle");
+            });
+    }
 
     d3.selectAll("#paper_list_title").on("click", function(d) {
         mediator.publish("list_title_clickable", d);

--- a/vis/js/mediator.js
+++ b/vis/js/mediator.js
@@ -45,7 +45,7 @@ var MyMediator = function() {
     this.mediator = new Mediator();
     this.manager = new ModuleManager();
     this.modern_frontend_enabled = config.modern_frontend_enabled
-    this.modern_frontend_intermediate = new Intermediate(this.modern_frontend_enabled, this.chart_svg_click, this.streamgraph_chart_clicked)
+    this.modern_frontend_intermediate = new Intermediate(this.modern_frontend_enabled, this.chart_svg_click, this.streamgraph_chart_clicked, this.list_toggle)
     this.init();
     this.init_state();
 };
@@ -89,6 +89,7 @@ MyMediator.prototype = {
         // list --> bookmarks
         this.mediator.subscribe("bookmark_added", this.bookmark_added);
         this.mediator.subscribe("bookmark_removed", this.bookmark_removed);
+        this.mediator.subscribe("list_item_count_change", this.list_item_count_change);
 
         // papers events
         this.mediator.subscribe("paper_click", this.paper_click);
@@ -172,6 +173,10 @@ MyMediator.prototype = {
 
     init_modern_frontend_intermediate: function() {
         mediator.modern_frontend_intermediate.init(config, io.context);
+    },
+
+    render_modern_frontend_list: function() {
+        mediator.modern_frontend_intermediate.renderList();
     },
 
     register_bubbles: function() {
@@ -342,6 +347,8 @@ MyMediator.prototype = {
             mediator.manager.call('canvas', 'dotdotdotAreaTitles', []);
             mediator.manager.call('bubble', 'initMouseListeners', []);
         }
+
+        mediator.render_modern_frontend_list();
 
         mediator.manager.call('canvas', 'showInfoModal', []);
     },
@@ -720,6 +727,13 @@ MyMediator.prototype = {
         mediator.manager.call('canvas', 'dotdotdotAreaTitles', []);
     },
 
+    list_item_count_change: function(count) {
+        if (!mediator.modern_frontend_enabled) {
+            $('#list_item_count').text(count);
+        } else {
+            mediator.modern_frontend_intermediate.changeItemsCount(count);
+        }
+    },
 };
 
 export const mediator = new MyMediator();

--- a/vis/js/mediator.js
+++ b/vis/js/mediator.js
@@ -329,7 +329,7 @@ MyMediator.prototype = {
             mediator.manager.call('canvas', 'initEventsStreamgraph', []);
             
             mediator.manager.call('list', 'start');
-            if (config.show_list) mediator.manager.call('list', 'show');
+            if (config.show_list) mediator.list_show();
             
             mediator.manager.call('streamgraph', 'initMouseListeners', []);
             
@@ -340,7 +340,7 @@ MyMediator.prototype = {
             mediator.manager.call('bubble', 'draw', []);
 
             mediator.manager.call('list', 'start');
-            if (!config.render_bubbles && config.show_list) mediator.manager.call('list', 'show');
+            if (!config.render_bubbles && config.show_list) mediator.list_show();
 
             mediator.manager.call('canvas', 'checkForcePapers', []);
             mediator.manager.call('canvas', 'hyphenateAreaTitles', []);
@@ -442,6 +442,13 @@ MyMediator.prototype = {
         mediator.manager.call('list', 'toggle', []);
     },
 
+    list_show: function() {
+        if (mediator.modern_frontend_enabled) {
+            mediator.modern_frontend_intermediate.showList();
+        }
+        mediator.manager.call('list', 'show', []);
+    },
+
     list_show_popup: function(d) {
         mediator.manager.call('list', 'populateOverlay', [d]);
     },
@@ -466,7 +473,7 @@ MyMediator.prototype = {
     paper_holder_clicked: function(holder) {
         mediator.manager.call('list', 'enlargeListItem', [holder]);
         if (mediator.modules.list.current == "hidden") {
-            mediator.manager.call('list', 'show', []);
+            mediator.list_show();
         }
         mediator.current_enlarged_paper = holder;
         mediator.manager.call('list', 'count_visible_items_to_header', []);
@@ -659,7 +666,7 @@ MyMediator.prototype = {
 
     check_force_papers: function() {
         if (config.show_list) {
-            mediator.manager.call('list', 'show', []);
+            mediator.list_show();
         }
         mediator.manager.call('list', 'count_visible_items_to_header')
     },

--- a/vis/js/reducers/index.js
+++ b/vis/js/reducers/index.js
@@ -11,6 +11,7 @@ import query from "./query";
 import files from "./files";
 import contextLine from "./contextLine";
 import service from "./service";
+import list from "./list";
 
 export default combineReducers({
   zoom,
@@ -22,4 +23,5 @@ export default combineReducers({
   files,
   contextLine,
   service,
+  list,
 });

--- a/vis/js/reducers/list.js
+++ b/vis/js/reducers/list.js
@@ -1,0 +1,23 @@
+const list = (state = { show: true, docsNumber: 0 }, action) => {
+  switch (action.type) {
+    case "INITIALIZE":
+      return {
+        ...state,
+        // TODO init data (shown list, number of all documents)
+      };
+    case "TOGGLE_LIST":
+      return {
+        ...state,
+        show: !state.show,
+      };
+    case "SET_ITEMS_COUNT":
+      return {
+        ...state,
+        docsNumber: action.count,
+      };
+    default:
+      return state;
+  }
+};
+
+export default list;

--- a/vis/js/reducers/list.js
+++ b/vis/js/reducers/list.js
@@ -10,6 +10,11 @@ const list = (state = { show: true, docsNumber: 0 }, action) => {
         ...state,
         show: !state.show,
       };
+    case "SHOW_LIST":
+      return {
+        ...state,
+        show: true,
+      };
     case "SET_ITEMS_COUNT":
       return {
         ...state,

--- a/vis/js/reducers/list.js
+++ b/vis/js/reducers/list.js
@@ -3,7 +3,8 @@ const list = (state = { show: true, docsNumber: 0 }, action) => {
     case "INITIALIZE":
       return {
         ...state,
-        // TODO init data (shown list, number of all documents)
+        show: !!action.configObject.show_list,
+        // TODO init number of all documents
       };
     case "TOGGLE_LIST":
       return {

--- a/vis/js/templates/ListToggle.jsx
+++ b/vis/js/templates/ListToggle.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+const ListToggle = ({ toggleLabel, docsNumber, docsNumberLabel, onClick }) => {
+  return (
+    // html template starts here
+    // TODO in the next refactoring step, move the div here and remove
+    // the onClick events from children
+    //<div id="show_hide_button" className="row" onClick={onClick}>
+    <>
+      <div className="col-xs-2" onClick={onClick}>▼</div>
+      <div className="col-xs-8" id="show_hide_button_label" onClick={onClick}>
+        <span id="show_hide_label">
+          <span>
+            {toggleLabel}{" "}
+            <span id="list_item_banner">
+              (<span id="list_item_count">{docsNumber}</span> {docsNumberLabel})
+            </span>
+          </span>
+        </span>
+      </div>
+      <div className="col-xs-2 text-right" onClick={onClick}>▼</div>
+    </>
+    //</div>
+    // html template ends here
+  );
+};
+
+export default ListToggle;

--- a/vis/stylesheets/modules/list/_list-show-button.scss
+++ b/vis/stylesheets/modules/list/_list-show-button.scss
@@ -5,7 +5,7 @@
     background-color: white;
     color: $black;
 
-    &.hover {
+    &:hover {
         background-color: $list_show_hide_button;
         color: white;
     }

--- a/vis/templates/list/list_explorer.handlebars
+++ b/vis/templates/list/list_explorer.handlebars
@@ -1,11 +1,13 @@
 <div class="">
     <div class="col-xs-12" id="explorer_header">
         <div id="show_hide_button" class="row">
+            {{#unless modern_frontend_enabled}}
             <div class="col-xs-2" >▼</div>
             <div class="col-xs-8" id="show_hide_button_label">
                 <span id="show_hide_label"></span>
             </div>
             <div class="col-xs-2 text-right">▼</div>
+            {{/unless}}
         </div>
 
         <div id="explorer_options" class="row">

--- a/vis/test/component/listtoggle.test.js
+++ b/vis/test/component/listtoggle.test.js
@@ -1,0 +1,109 @@
+import React from "react";
+import { render, unmountComponentAtNode } from "react-dom";
+import { act } from "react-dom/test-utils";
+
+import configureStore from "redux-mock-store";
+
+import { toggleList } from "../../js/actions";
+
+import ListToggle from "../../js/components/ListToggle";
+
+const mockStore = configureStore([]);
+const setup = (overrideListObject = {}, overrideStoreObject = {}) => {
+  const storeObject = Object.assign(
+    {
+      list: {
+        show: false,
+        docsNumber: 100,
+        ...overrideListObject
+      },
+      localization: {
+        show_list: "show list",
+        hide_list: "hide list",
+        items: "items",
+      },
+    },
+    overrideStoreObject
+  );
+
+  return storeObject;
+};
+
+describe("List toggle component", () => {
+  let container = null;
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    unmountComponentAtNode(container);
+    container.remove();
+    container = null;
+  });
+
+  it("renders shown", () => {
+    const storeObject = setup({show: true});
+    const store = mockStore(storeObject);
+
+    act(() => {
+      render(<ListToggle store={store} />, container);
+    });
+
+    expect(container.querySelector("#show_hide_label").textContent).toContain(storeObject.localization.hide_list);
+  });
+
+  it("renders hidden", () => {
+    const storeObject = setup({show: false});
+    const store = mockStore(storeObject);
+
+    act(() => {
+      render(<ListToggle store={store} />, container);
+    });
+
+    expect(container.querySelector("#show_hide_label").textContent).toContain(storeObject.localization.show_list);
+  });
+
+  it("renders with correct document number", () => {
+    const DOCS_NUMBER = 42;
+    const storeObject = setup({docsNumber: DOCS_NUMBER});
+    const store = mockStore(storeObject);
+
+    act(() => {
+      render(<ListToggle store={store} />, container);
+    });
+
+    expect(container.querySelector("#list_item_count").textContent).toEqual(DOCS_NUMBER.toString());
+  });
+
+  it("triggers a correct redux action when clicked", () => {
+    const EXPECTED_PAYLOAD = toggleList();
+
+    // TODO remove this when warn is removed
+    global.console = {
+      log: console.log,
+      warn: jest.fn(),
+      error: console.error,
+      info: console.info,
+      debug: console.debug,
+    };
+
+    const storeObject = setup();
+    const store = mockStore(storeObject);
+
+    act(() => {
+      render(<ListToggle store={store} />, container);
+    });
+
+    // TODO change this for the #show_hide_button
+    const toggle = document.querySelector("#show_hide_button_label");
+    act(() => {
+      const event = new Event("click", { bubbles: true });
+      toggle.dispatchEvent(event);
+    });
+
+    const actions = store.getActions();
+
+    expect(actions).toEqual([EXPECTED_PAYLOAD]);
+  });
+});

--- a/vis/test/snapshot/__snapshots__/listtoggle.test.js.snap
+++ b/vis/test/snapshot/__snapshots__/listtoggle.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`List toggle component snapshot matches a snapshot 1`] = `
+Array [
+  <div
+    className="col-xs-2"
+    onClick={[Function]}
+  >
+    ▼
+  </div>,
+  <div
+    className="col-xs-8"
+    id="show_hide_button_label"
+    onClick={[Function]}
+  >
+    <span
+      id="show_hide_label"
+    >
+      <span>
+        Liste einklappen
+         
+        <span
+          id="list_item_banner"
+        >
+          (
+          <span
+            id="list_item_count"
+          >
+            42
+          </span>
+           
+          Dokumente
+          )
+        </span>
+      </span>
+    </span>
+  </div>,
+  <div
+    className="col-xs-2 text-right"
+    onClick={[Function]}
+  >
+    ▼
+  </div>,
+]
+`;

--- a/vis/test/snapshot/listtoggle.test.js
+++ b/vis/test/snapshot/listtoggle.test.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { Provider } from "react-redux";
+import renderer from "react-test-renderer";
+import configureStore from "redux-mock-store";
+
+import ListToggle from "../../js/components/ListToggle";
+
+const mockStore = configureStore([]);
+
+describe("List toggle component snapshot", () => {
+  it("matches a snapshot", () => {
+    const store = mockStore({
+      list: {
+        show: true,
+        docsNumber: 42,
+      },
+      localization: {
+        hide_list: "Liste einklappen",
+        items: "Dokumente",
+      },
+    });
+    const tree = renderer
+      .create(
+        <Provider store={store}>
+          <ListToggle />
+        </Provider>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/vis/test/store/initialize.test.js
+++ b/vis/test/store/initialize.test.js
@@ -6,6 +6,7 @@ import queryReducer from "../../js/reducers/query";
 import filesReducer from "../../js/reducers/files";
 import contextLineReducer from "../../js/reducers/contextLine";
 import serviceReducer from "../../js/reducers/service";
+import listReducer from "../../js/reducers/list";
 
 const setup = (overrideConfig, overrideContext) => {
   const configObject = Object.assign(
@@ -1663,6 +1664,31 @@ describe("config and context state", () => {
       );
 
       expect(result).toEqual(SERVICE);
+    });
+  });
+
+  describe("list reducer", () => {
+    // initial state tested in listtoggle.test.js
+
+    it("should not change the state with initialization", () => {
+      const INITIAL_STATE = { show: true, docsNumber: 0 };
+      const EXPECTED_STATE = INITIAL_STATE;
+
+      const { configObject, contextObject } = setup(
+        {
+          whatever: "whatever",
+        },
+        {
+          whatever: "whatever",
+        }
+      );
+
+      const result = listReducer(
+        INITIAL_STATE,
+        initializeStore(configObject, contextObject)
+      );
+
+      expect(result).toEqual(EXPECTED_STATE);
     });
   });
 });

--- a/vis/test/store/initialize.test.js
+++ b/vis/test/store/initialize.test.js
@@ -710,7 +710,7 @@ describe("config and context state", () => {
           params: {
             author_id: 111,
             living_dates: "1620-1699",
-            image_link: "http://link.com/1234"
+            image_link: "http://link.com/1234",
           },
         }
       );
@@ -1035,7 +1035,7 @@ describe("config and context state", () => {
       const initialState = {};
       const { configObject, contextObject } = setup(
         {
-          options: JSON.parse(REAL_CONFIG_OPTIONS)
+          options: JSON.parse(REAL_CONFIG_OPTIONS),
         },
         {
           params: {
@@ -1485,7 +1485,7 @@ describe("config and context state", () => {
           service: SERVICE,
           params: {
             min_descsize: MIN_DESCSIZE,
-          }
+          },
         }
       );
 
@@ -1509,7 +1509,7 @@ describe("config and context state", () => {
           service: SERVICE,
           params: {
             min_descsize: MIN_DESCSIZE,
-          }
+          },
         }
       );
 
@@ -1533,7 +1533,7 @@ describe("config and context state", () => {
           service: SERVICE,
           params: {
             min_descsize: MIN_DESCSIZE,
-          }
+          },
         }
       );
 
@@ -1557,7 +1557,7 @@ describe("config and context state", () => {
           service: SERVICE,
           params: {
             min_descsize: MIN_DESCSIZE,
-          }
+          },
         }
       );
 
@@ -1581,7 +1581,7 @@ describe("config and context state", () => {
           service: SERVICE,
           params: {
             min_descsize: MIN_DESCSIZE,
-          }
+          },
         }
       );
 
@@ -1605,7 +1605,7 @@ describe("config and context state", () => {
           service: SERVICE,
           params: {
             min_descsize: MIN_DESCSIZE,
-          }
+          },
         }
       );
 
@@ -1672,15 +1672,14 @@ describe("config and context state", () => {
 
     it("should not change the state with initialization", () => {
       const INITIAL_STATE = { show: true, docsNumber: 0 };
-      const EXPECTED_STATE = INITIAL_STATE;
+      const SHOW_LIST = false;
+      const EXPECTED_STATE = { ...INITIAL_STATE, show: SHOW_LIST };
 
       const { configObject, contextObject } = setup(
         {
-          whatever: "whatever",
+          show_list: SHOW_LIST,
         },
-        {
-          whatever: "whatever",
-        }
+        {}
       );
 
       const result = listReducer(

--- a/vis/test/store/listtoggle.test.js
+++ b/vis/test/store/listtoggle.test.js
@@ -1,0 +1,51 @@
+import { toggleList, setItemsCount } from "../../js/actions";
+
+import listReducer from "../../js/reducers/list";
+
+describe("list toggle state", () => {
+  describe("actions", () => {
+    it("should create a list toggle action", () => {
+      const expectedAction = {
+        type: "TOGGLE_LIST",
+      };
+      expect(toggleList()).toEqual(expectedAction);
+    });
+
+    it("should create a change of items count action", () => {
+      const COUNT = 11;
+      const expectedAction = {
+        type: "SET_ITEMS_COUNT",
+        count: COUNT
+      };
+      expect(setItemsCount(COUNT)).toEqual(expectedAction);
+    });
+  });
+  
+  describe("reducers", () => {
+    it("should return the initial state", () => {
+      const expectedResult = { show: true, docsNumber: 0 };
+
+      const result = listReducer(undefined, {});
+
+      expect(result).toEqual(expectedResult);
+    });
+
+    it("should set show to 'false'", () => {
+      const INITIAL_STATE = { show: true, docsNumber: 0 };
+      const EXPECTED_STATE = { ...INITIAL_STATE, show: false };
+
+      const result = listReducer(INITIAL_STATE, toggleList());
+
+      expect(result).toEqual(EXPECTED_STATE);
+    });
+
+    it("should set the number of documents", () => {
+      const INITIAL_STATE = { show: true, docsNumber: 0 };
+      const EXPECTED_STATE = { ...INITIAL_STATE, docsNumber: 42 };
+
+      const result = listReducer(INITIAL_STATE, setItemsCount(42));
+
+      expect(result).toEqual(EXPECTED_STATE);
+    });
+  });
+});

--- a/vis/test/store/listtoggle.test.js
+++ b/vis/test/store/listtoggle.test.js
@@ -1,4 +1,4 @@
-import { toggleList, setItemsCount } from "../../js/actions";
+import { toggleList, showList, setItemsCount } from "../../js/actions";
 
 import listReducer from "../../js/reducers/list";
 
@@ -9,6 +9,13 @@ describe("list toggle state", () => {
         type: "TOGGLE_LIST",
       };
       expect(toggleList()).toEqual(expectedAction);
+    });
+
+    it("should create a list show action", () => {
+      const expectedAction = {
+        type: "SHOW_LIST",
+      };
+      expect(showList()).toEqual(expectedAction);
     });
 
     it("should create a change of items count action", () => {
@@ -35,6 +42,15 @@ describe("list toggle state", () => {
       const EXPECTED_STATE = { ...INITIAL_STATE, show: false };
 
       const result = listReducer(INITIAL_STATE, toggleList());
+
+      expect(result).toEqual(EXPECTED_STATE);
+    });
+
+    it("should set show to 'true'", () => {
+      const INITIAL_STATE = { show: false, docsNumber: 0 };
+      const EXPECTED_STATE = { ...INITIAL_STATE, show: true };
+
+      const result = listReducer(INITIAL_STATE, showList());
 
       expect(result).toEqual(EXPECTED_STATE);
     });


### PR DESCRIPTION
This PR introduces the 1st part of the List component refactoring: the refactored toggle subcomponent.

The new code can be tested by building the application with MODERN_FRONTEND=true.

**Main features:**

Redux:

- There are three new actions: TOGGLE_LIST (triggered by clicking the toggle), SHOW_LIST (triggered by mediator e.g. when paper in map is clicked) and SET_ITEMS_COUNT (sets a counter of displayed papers - temporary solution until full data is stored in the redux store).
- New reducer for the list data: it shows that the list toggle reacts to multiple events (initialization, list toggle, showing the list).

Components:

- Simple template ListToggle created. Its container, div id="show_hide_button", has to keep in the handlebars for now, so the onclick events are bound to each element in the container. This will change once the whole list is refactored. It may also cause a small bug: sometimes when the toggle is clicked too fast after mouseover, nothing happens.
- This template is simply given data from the store, no logic required.

Legacy code:

- Intermediate layer glues the behavior together: one way with the `createListToggleMiddleware` middleware, one way with a function that triggers the `showList` action.
- List is rendered in a separate function in the intermediate layer, because it has to be rendered later than the MVP.
- I had to create some new mediator methods to push some operations closer to the intermediate.
- CSS style simplified: instead of adding "hover" class on mouseover, I simply added the :hover style.

Testing:

- 100% code coverage, including a simple snapshot test.

**Known bugs:**

- Toggle sometimes doesn't react to a click if it's clicked too fast after the mouseover. It's probably caused by the fact that the onclick event isn't bound to the whole subcomponent, but rather to each of its elements. I'll solve this later in the list refactoring.