### PR TITLE
Added missing space in the covis comments

### DIFF
--- a/vis/js/templates/listentry/Comments.jsx
+++ b/vis/js/templates/listentry/Comments.jsx
@@ -22,7 +22,7 @@ const Comments = ({ items }) => {
               <>
                 <span id="comment-by-label">
                   {localization.comment_by_label}
-                </span>
+                </span>{" "}
                 <span id="comment-author" className="comment-author">
                   <Highlight>{comment.author}</Highlight>
                 </span>


### PR DESCRIPTION
Added a missing space between "by" and "comment author" in Covis.