### PR TITLE
Added modal buttons positioning

### DIFF
--- a/vis/js/components/ModalButtons.js
+++ b/vis/js/components/ModalButtons.js
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { connect } from "react-redux";
 
 import { openEmbedModal, openViperEditModal } from "../actions";
+
+import $ from "jquery";
 
 import EditButton from "../templates/buttons/EditButton";
 import EmbedButton from "../templates/buttons/EmbedButton";
@@ -21,7 +23,16 @@ const ModalButtons = ({
   showReloadButton,
   reloadLastUpdate,
   reloadApiProperties,
+  isEmbedded,
+  visTag,
+  service,
 }) => {
+  useEffect(() => {
+    if (["base", "pubmed"].includes(service) && !isEmbedded) {
+      positionButtons(visTag);
+    }
+  });
+
   return (
     <div id="modals">
       {showShareButton && <ShareButton twitterHashtags={twitterHashtags} />}
@@ -50,6 +61,9 @@ const mapStateToProps = (state) => ({
   showReloadButton: state.modals.showReloadButton,
   reloadLastUpdate: state.modals.reloadLastUpdate,
   reloadApiProperties: state.modals.reloadApiProperties,
+  isEmbedded: state.misc.showCreatedBy,
+  visTag: state.misc.visTag,
+  service: state.modals.service,
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -58,3 +72,52 @@ const mapDispatchToProps = (dispatch) => ({
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ModalButtons);
+
+// legacy code from project website that sets the modal buttons position
+$.fn.followTo = function (pos, top_pos, left_pos) {
+  var $this = this,
+    $window = $(window);
+
+  const setPosition = function () {
+    if ($window.scrollTop() > pos - top_pos) {
+      $this.css({
+        position: "absolute",
+        top: pos,
+        left: 0,
+      });
+    } else {
+      $this.css({
+        position: "fixed",
+        top: top_pos,
+        left: left_pos,
+      });
+    }
+  };
+  $window.scroll(setPosition);
+  setPosition();
+};
+
+const positionButtons = (tag) => {
+  var topPosition = $("#modals").position().top;
+
+  const setPosition = () => {
+    const height = parseInt($("#" + tag).css("min-height"));
+    const leftOffset = $("#visualization").offset().left;
+
+    $("#modals").followTo(height, topPosition, leftOffset, 0);
+  };
+
+  $(".close").click(function () {
+    $("#modals").css(
+      "top",
+      $("#modals").position().top - $("#desktop-warning").outerHeight()
+    );
+
+    topPosition = $("#modals").position().top;
+    setPosition();
+  });
+
+  $(window).resize(setPosition);
+
+  setPosition();
+};

--- a/vis/js/reducers/misc.js
+++ b/vis/js/reducers/misc.js
@@ -18,6 +18,7 @@ const misc = (state = { isLoading: true, showLoading: false }, action) => {
         renderMap: action.configObject.render_map,
         renderList: action.configObject.render_list,
         isLoading: false,
+        visTag: action.configObject.tag,
       };
     default:
       return state;


### PR DESCRIPTION
I moved the modal buttons positioning from the project website repository to Headstart.

This function is still restricted only to .org data integration.

Please merge it together with the PR in the project website repository: https://github.com/OpenKnowledgeMaps/project-website/pull/74 