### PR TITLE
Renamed TRIPLE to GoTriple

### DIFF
--- a/vis/js/default-config.js
+++ b/vis/js/default-config.js
@@ -214,8 +214,8 @@ var config = {
                         , linkedcat: "LinkedCat+"
                         , linkedcat_authorview: "LinkedCat+"
                         , linkedcat_browseview: "LinkedCat+"
-                        , triple_km: "TRIPLE"
-                        , triple_sg: "TRIPLE"
+                        , triple_km: "GoTriple"
+                        , triple_sg: "GoTriple"
                     },
 
     localization: {


### PR DESCRIPTION
In the Headstart context line, I renamed the data source "TRIPLE" to "GoTriple".