### PR TITLE
TRIPLE -> GoTriple in builtwith

### DIFF
--- a/vis/js/templates/footers/TripleBuiltWith.jsx
+++ b/vis/js/templates/footers/TripleBuiltWith.jsx
@@ -12,7 +12,7 @@ const TripleBuiltWith = () => (
     </a>
     . All content retrieved from{" "}
     <a href="https://www.gotriple.eu/" target="_blank " rel="noreferrer">
-      TRIPLE
+      GoTriple
     </a>
     .
   </div>


### PR DESCRIPTION
I changed the label from _TRIPLE_ to _GoTriple_ in the "built with" footer.