### PR TITLE
Returned the provideplugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,9 @@ const common = {
         'chart': 'Chart'
     },
     plugins: [
+        new webpack.ProvidePlugin({
+            process: 'process/browser',
+        }),
         new MiniCssExtractPlugin({
             // Options similar to the same options in webpackOptions.output
             // all options are optional


### PR DESCRIPTION
I found out that localhost doesn't work without the _process/browser_ in the provider plugin.