### PR TITLE
Fixed covis/viper tags css

### DIFF
--- a/vis/js/templates/listentry/AccessIcons.jsx
+++ b/vis/js/templates/listentry/AccessIcons.jsx
@@ -7,21 +7,21 @@ const AccessIcons = ({ isOpenAccess, isFreeAccess, isDataset, tags }) => {
     // html template starts here
     <div id="oa">
       {!!isOpenAccess && (
-        <span id="open-access-logo_list">
-            <span className="access_icon outlink_symbol">&#61596;</span>
-            <Highlight>open access</Highlight>
+        <span className="paper-tag open-access-tag">
+          <span className="access_icon outlink_symbol">&#61596;</span>
+          <Highlight>open access</Highlight>
         </span>
       )}
       {!!isFreeAccess && (
-        <span id="free-access-logo_list" className="access_icon free-access-logo">
-            <span className="outlink_symbol">&#61596;</span>
-            <Highlight>free access </Highlight>
+        <span className="paper-tag free-access-tag">
+          <span className="access_icon outlink_symbol">&#61596;</span>
+          <Highlight>free access</Highlight>
         </span>
       )}
       {!!isDataset && (
-        <span id="dataset-icon_list" className="access_icon dataset-tag">
-            <span className="fa fa-database"></span>
-            <Highlight>dataset </Highlight>
+        <span className="paper-tag dataset-tag">
+          <span className="fa fa-database access_icon"></span>
+          <Highlight>dataset</Highlight>
         </span>
       )}
       {tags}

--- a/vis/js/templates/listentry/Tags.jsx
+++ b/vis/js/templates/listentry/Tags.jsx
@@ -5,9 +5,9 @@ import Highlight from "../../components/Highlight";
 const Tags = ({ values }) => {
   return (
     // html template starts here
-    <div id="list_tags" className="tags" style={{ display: "inline-block" }}>
+    <div className="tags">
       {values.map((tag) => (
-        <div className="tag" key={tag}>
+        <div className="paper-tag" key={tag}>
           <Highlight>{tag}</Highlight>
         </div>
       ))}

--- a/vis/stylesheets/modules/list/_entry.scss
+++ b/vis/stylesheets/modules/list/_entry.scss
@@ -22,54 +22,37 @@
     margin-bottom: 6px;
 }
 
-#open-access-logo_list, #free-access-logo_list {
-    background-color: white;
-    color: $open-access;
-    border: 1px solid $open-access;
+.tags {
+    display: inline-block;
+}
+
+.paper-tag {
+    display: inline-block;
     padding: 2px 4px;
+    width: 100px;
+    background-color: white;
+    
+    color: $medium-blue;
+    text-align: center;
+    font-size: 10px;
+    font-weight: $fontweight400;
+
+    border: 1px solid $medium-blue;
     border-radius: 14px;
     -webkit-border-radius: 14px;
     -moz-border-radius: 14px;
-    font-size: 10px;
-    font-weight: $fontweight400;
-    display: inline-block;
-    width: 100px;
-    text-align: center;
-}
 
-.tag {
-    background-color: white;
-    display: inline;
-    color: $medium-blue;
-    border: 1px solid $medium-blue;
-    padding: 2px 4px;
-    border-radius: 5px;
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    font-size: 10px;
-    font-weight: $fontweight400;
     margin-right: 3px;
 }
 
-.tags {
-    display: inline;
+.open-access-tag, .free-access-tag {
+    color: $open-access;
+    border-color: $open-access;
 }
 
 .dataset-tag {
     color: $dataset;
-    border: 1px solid $dataset;
-    background-color: white;
-    padding: 2px 4px;
-    border-radius: 14px;
-    -webkit-border-radius: 14px;
-    -moz-border-radius: 14px;
-    width: 100px;
-    text-align: center;
-    margin-left: 6px;
-}
-
-.fa-database {
-    margin-right: 3px;
+    border-color: $dataset;
 }
 
 .resulttype-dataset {
@@ -865,7 +848,7 @@ img#preview_page {
 
 @if $skin == "covis" {
 
-    #open-access-logo_list {
+    .open-access-tag {
         font-size: 10px;
         vertical-align: top;
         font-weight: $fontweight400;
@@ -935,10 +918,6 @@ img#preview_page {
     }
     #list_keywords {
         margin-bottom: 5px;
-    }
-
-    #free-access-logo_list, #open-access-logo_list {
-        margin-right: 3px;
     }
 
     #list_keywords {

--- a/vis/test/snapshot/__snapshots__/list-base.test.js.snap
+++ b/vis/test/snapshot/__snapshots__/list-base.test.js.snap
@@ -288,7 +288,7 @@ exports[`List entries component snapshot (BASE) matches a snapshot (zoomed-in, p
                   id="oa"
                 >
                   <span
-                    id="open-access-logo_list"
+                    className="paper-tag open-access-tag"
                   >
                     <span
                       className="access_icon outlink_symbol"
@@ -1204,7 +1204,7 @@ exports[`List entries component snapshot (BASE) matches a snapshot (zoomed-out) 
                   id="oa"
                 >
                   <span
-                    id="open-access-logo_list"
+                    className="paper-tag open-access-tag"
                   >
                     <span
                       className="access_icon outlink_symbol"
@@ -2082,7 +2082,7 @@ exports[`List entries component snapshot (BASE) matches a snapshot (zoomed-out) 
                   id="oa"
                 >
                   <span
-                    id="open-access-logo_list"
+                    className="paper-tag open-access-tag"
                   >
                     <span
                       className="access_icon outlink_symbol"
@@ -2259,7 +2259,7 @@ exports[`List entries component snapshot (BASE) matches a snapshot (zoomed-out) 
                   id="oa"
                 >
                   <span
-                    id="open-access-logo_list"
+                    className="paper-tag open-access-tag"
                   >
                     <span
                       className="access_icon outlink_symbol"
@@ -2489,7 +2489,7 @@ exports[`List entries component snapshot (BASE) matches a snapshot (zoomed-out) 
                   id="oa"
                 >
                   <span
-                    id="open-access-logo_list"
+                    className="paper-tag open-access-tag"
                   >
                     <span
                       className="access_icon outlink_symbol"
@@ -2692,7 +2692,7 @@ exports[`List entries component snapshot (BASE) matches a snapshot (zoomed-out) 
                   id="oa"
                 >
                   <span
-                    id="open-access-logo_list"
+                    className="paper-tag open-access-tag"
                   >
                     <span
                       className="access_icon outlink_symbol"
@@ -3096,7 +3096,7 @@ exports[`List entries component snapshot (BASE) matches a snapshot (zoomed-out) 
                   id="oa"
                 >
                   <span
-                    id="open-access-logo_list"
+                    className="paper-tag open-access-tag"
                   >
                     <span
                       className="access_icon outlink_symbol"
@@ -3611,7 +3611,7 @@ exports[`List entries component snapshot (BASE) matches a snapshot (zoomed-out) 
                   id="oa"
                 >
                   <span
-                    id="open-access-logo_list"
+                    className="paper-tag open-access-tag"
                   >
                     <span
                       className="access_icon outlink_symbol"
@@ -3962,7 +3962,7 @@ exports[`List entries component snapshot (BASE) matches a snapshot (zoomed-out) 
                   id="oa"
                 >
                   <span
-                    id="open-access-logo_list"
+                    className="paper-tag open-access-tag"
                   >
                     <span
                       className="access_icon outlink_symbol"
@@ -4139,7 +4139,7 @@ exports[`List entries component snapshot (BASE) matches a snapshot (zoomed-out) 
                   id="oa"
                 >
                   <span
-                    id="open-access-logo_list"
+                    className="paper-tag open-access-tag"
                   >
                     <span
                       className="access_icon outlink_symbol"
@@ -4445,7 +4445,7 @@ exports[`List entries component snapshot (BASE) matches a snapshot (zoomed-out) 
                   id="oa"
                 >
                   <span
-                    id="open-access-logo_list"
+                    className="paper-tag open-access-tag"
                   >
                     <span
                       className="access_icon outlink_symbol"


### PR DESCRIPTION
Paper tags css (in list) needed some adjustments. I united the styles into one common class `paper-tag` and added this class to all tag types (open access, free access, dataset, custom tags).