### PR TITLE
Interface changes export backend

### DIFF
--- a/server/services/exportMetadata.php
+++ b/server/services/exportMetadata.php
@@ -27,6 +27,10 @@ if (isset($result["status"]) && $result["status"] === "error") {
     echo json_encode($result);
 }
 
+if ($format == "bibtex") {
+    $format = "bib";
+}
+
 if (isset($download) & $download==true ) {
     header('Content-type: application/text');
     header('Content-Disposition: attachment; filename=metadata.' . $format);

--- a/server/workers/api/src/apis/export.py
+++ b/server/workers/api/src/apis/export.py
@@ -23,7 +23,7 @@ def transform2bibtex(metadata):
     # use different field for ID
     title = metadata.get("title", "")
     author = metadata.get("authors", "")
-    if year in metadata:
+    if "year" in metadata:
         parsed_date = parse_date(metadata.get("year", ""))
         year = parsed_date.year
     else:

--- a/server/workers/api/src/apis/export.py
+++ b/server/workers/api/src/apis/export.py
@@ -25,7 +25,7 @@ def transform2bibtex(metadata):
     author = metadata.get("authors", "")
     if "year" in metadata:
         parsed_date = parse_date(metadata.get("year", ""))
-        year = parsed_date.year
+        year = parsed_date["year"]
     else:
         year = ""
     doi = metadata.get("doi", "")

--- a/server/workers/api/src/apis/export.py
+++ b/server/workers/api/src/apis/export.py
@@ -25,7 +25,7 @@ def transform2bibtex(metadata):
     author = metadata.get("authors", "")
     if "year" in metadata:
         parsed_date = parse_date(metadata.get("year", ""))
-        year = parsed_date["year"]
+        year = str(parsed_date["year"])
     else:
         year = ""
     doi = metadata.get("doi", "")

--- a/server/workers/api/src/apis/export.py
+++ b/server/workers/api/src/apis/export.py
@@ -4,8 +4,16 @@ from flask import Blueprint, request, make_response, jsonify, abort
 from flask_restx import Namespace, Resource, fields
 from bibtexparser.bwriter import BibTexWriter 
 from bibtexparser.bibdatabase import BibDatabase
+import dateutil.parser as parser
 
 export_ns = Namespace("export", description="metadata export API operations")
+
+
+def parse_date(date):
+    parsed_date = {}
+    tmp = parser.parse(date)
+    parsed_date["year"] = tmp.year
+    return parsed_date
 
 def transform2bibtex(metadata):
     # TODO: add mapping from resulttype to ARTICLETYPE
@@ -15,7 +23,11 @@ def transform2bibtex(metadata):
     # use different field for ID
     title = metadata.get("title", "")
     author = metadata.get("authors", "")
-    year = metadata.get("year", "")
+    if year in metadata:
+        parsed_date = parse_date(metadata.get("year", ""))
+        year = parsed_date.year
+    else:
+        year = ""
     doi = metadata.get("doi", "")
     id = metadata.get("id", "")
     published_in = metadata.get("published_in", "")


### PR DESCRIPTION
This PR gets the export functionality working for Mendeley by
* changing the download file-format from ".bibtex" to ".bib"
* reducing the date information in the "year" field to "yyyy"