### PR TITLE
Fix api errorhandling for false 0-results errors

### DIFF
--- a/server/classes/headstart/library/APIClient.php
+++ b/server/classes/headstart/library/APIClient.php
@@ -30,18 +30,61 @@ class APIClient {
 
     public function call_api($endpoint, $payload) {
         $route = $this->base_route . $endpoint;
-        $res = CommUtils::call_api($route, $payload);
-        if ($res["httpcode"] != 200) {
-            $res["route"] = $route;
+        try {
+            $res = CommUtils::call_api($route, $payload);
+            if ($res["httpcode"] != 200) {
+                $res["route"] = $route;
+                $res = $this->handle_api_errors($res);
+            }
+            return $res;
         }
-        return $res;
+        catch (Exception $e) {
+            $res = array("status"=>"error",
+                         "httpcode"=>500,
+                         "reason"=>array("unexpected data processing error"));
+            error_log(print_r($res, TRUE));
+            return $res;
+        }
+        finally {
+        }        
     }
 
     public function call_persistence($endpoint, $payload) {
         $route = $this->base_route . "persistence/" . $endpoint . "/" . $this->database;
-        $res = CommUtils::call_api($route, $payload);
-        if ($res["httpcode"] != 200) {
-            $res["route"] = $route;
+        try {
+            $res = CommUtils::call_api($route, $payload);
+            if ($res["httpcode"] != 200) {
+                $res["route"] = $route;
+                $res = $this->handle_api_errors($res);
+            }
+            return $res;
+        }
+        catch (Exception $e) {
+            $res = array("status"=>"error",
+                         "httpcode"=>500,
+                         "reason"=>array("unexpected data processing error"));
+            error_log(print_r($res, TRUE));
+            return $res;
+        }
+        finally {
+        }        
+    }
+
+    public function handle_api_errors($res) {
+        // if (is_string($res)) {
+        //     if (str_contains($res, "503 Service Unavailable")) {
+        //         $res = array("status"=>"error", reason=>array());
+        //     }
+        // }
+        if ($res["httpcode"] == 503) {
+            $res["status"] = "error";
+            $res["reason"] = array();
+        }
+        if (!array_key_exists("reason", $res)) {
+            $res["reason"] = array();
+        }
+        if (count($res["reason"])==0) {
+            array_push($res["reason"], "unexpected data processing error");
         }
         return $res;
     }

--- a/server/workers/README.md
+++ b/server/workers/README.md
@@ -1,3 +1,6 @@
+# This documentation is not up-to-date and following it will not result in a running server backend for Headstart. We apologize for any inconvenience this may cause and ask for patience until the public documentation has been updated.
+
+
 ## Folder structure
 
 Following backend component containers are currently in `workers`:

--- a/server/workers/README.md
+++ b/server/workers/README.md
@@ -1,4 +1,4 @@
-# This documentation is not up-to-date and following it will not result in a running server backend for Headstart. We apologize for any inconvenience this may cause and ask for patience until the public documentation has been updated.
+## This documentation is not up-to-date and following it will not result in a running server backend for Headstart. We apologize for any inconvenience this may cause and ask for patience until the public documentation has been updated.
 
 
 ## Folder structure


### PR DESCRIPTION
This PR fixes a few loopholes in the error handling logic of the backend. It prevents the display of "Not enough results" errors in the search-flow in cases where the root cause is actually an outage of the backend-API or an error that is not recognizable by the data client error heuristics.