### PR TITLE
add logging for PHP stderr to searchflow container

### DIFF
--- a/local_dev/searchflow-container/Dockerfile
+++ b/local_dev/searchflow-container/Dockerfile
@@ -32,3 +32,5 @@ ENV NPM_PATH  $NVM_DIR/versions/node/v$NODE_VERSION/bin/npm
 RUN $NPM_PATH install -g puppeteer@^2.0.0 --unsafe-perm=true --allow-root
 
 RUN sed -i 's#AllowOverride [Nn]one#AllowOverride All#' /etc/apache2/apache2.conf
+COPY local_dev.ini /usr/local/etc/php/conf.d/local_dev.ini
+RUN chown root:root /usr/local/etc/php/conf.d/local_dev.ini

--- a/local_dev/searchflow-container/local_dev.ini
+++ b/local_dev/searchflow-container/local_dev.ini
@@ -1,0 +1,1 @@
+log_errors = On

--- a/server/services/getPDF.php
+++ b/server/services/getPDF.php
@@ -19,6 +19,9 @@ $service = library\CommUtils::getParameter($_GET, "service");
 $pdf_urls = library\CommUtils::getParameter($_GET, "pdf_urls");
 $images_path = $ini_array["general"]["images_path"];
 
+error_log("getPDF.php: url: " . $url);
+error_log("getPDF.php: filename: " . $filename);
+
 if ($service == "base" || $service == "openaire") {
   $pdf_link = getPDFLinkforBASE($pdf_urls);
   if($pdf_link != false) {


### PR DESCRIPTION
This change enables logging to STDERR from PHP files in the searchflow container for local dev environments.