### PR TITLE
feat: pretter configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 /config.js
 .cache
 coverage/
+local_dev/paper_preview/
 
 # local deployment files
 /deploy.sh
@@ -72,6 +73,7 @@ server/preprocessing/other-scripts/renv
 
 # personal
 .vscode/settings.json
+
 # temporal
 local_dev/config_local_headstart.ini
 local_dev/config_local_searchflow.ini

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,17 @@
+# Folders that should not be checked by Prettier
+.github/
+.pytest_cache/
+.vscode/
+api_cache/
+checks/
+dist/
+doc/
+examples/
+local_dev/
+node_modules/
+server/
+
+# Exact files that should not be checked by Prettier
+.docker.test.env
+.flake8
+CHANGELOG.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,16 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "quoteProps": "consistent",
+  "jsxSingleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "always",
+  "proseWrap": "always",
+  "endOfLine": "lf",
+  "embeddedLanguageFormatting": "auto"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "jsdom": "^25.0.0",
         "mini-css-extract-plugin": "^2.3.0",
         "node-fetch": "^2.7.0",
+        "prettier": "^3.5.3",
         "process": "^0.11.10",
         "react-test-renderer": "^16.13.1",
         "redux-mock-store": "^1.5.4",
@@ -10274,6 +10275,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "dev": "webpack --progress --watch --mode=development",
     "prod": "webpack --progress",
     "start": "webpack serve --progress --mode=development --env publicPath=http://localhost:8080/dist/",
-    "lint": "eslint \"./vis/js/**/*.js?(x)\""
+    "lint": "eslint \"./vis/js/**/*.js?(x)\"",
+    "prettier:check": "prettier . --check",
+    "prettier:fix": "prettier . --write"
   },
   "repository": {
     "type": "git",
@@ -80,6 +82,7 @@
     "jsdom": "^25.0.0",
     "mini-css-extract-plugin": "^2.3.0",
     "node-fetch": "^2.7.0",
+    "prettier": "^3.5.3",
     "process": "^0.11.10",
     "react-test-renderer": "^16.13.1",
     "redux-mock-store": "^1.5.4",

--- a/vis/index.ts
+++ b/vis/index.ts
@@ -1,2 +1,2 @@
-import { start } from './app';
+import { start } from "./app";
 export { start };


### PR DESCRIPTION
Added Prettier configuration. It is allows to format code on save, not to discuss or make decisions about code style during a code review, saves time during the development process. Documentation: [docs](https://prettier.io/); 

Also two new scripts were added into the package.json. To check how many files do not fit the formatting rules it is possible to call the `npm run prettier:check` command. To fix all formatting problems, the `npm run prettier:fix` one can be used.