### PR TITLE
refactor: remove deprecated utf8_encode

### DIFF
--- a/server/services/search.php
+++ b/server/services/search.php
@@ -11,6 +11,36 @@ require 'helper.php';
 
 use headstart\library;
 
+/**
+ * Convert a string from one character encoding to another
+ * @param string $str - String to be converted.
+ * @param string $to_encoding - Target encoding that will be applied to $str.
+ * @return string - Encoded $str.
+ */
+function encode_string(string $str, string $to_encoding = 'UTF-8'): string {
+  // Defining constants with known encodings and default one
+  $DEFAULT_ENCODING = 'ISO-8859-1';
+  $ENCODINGS = [
+    'UTF-8',
+    'Windows-1251',
+    'ISO-8859-1',
+    'ASCII',
+    'KOI8-R',
+    'CP866'
+  ];
+
+  // Trying to define the received string encoding
+  $str_encoding = mb_detect_encoding($str, $ENCODINGS, true);
+
+  // If the received string encoding is unknown the default one will be used
+  if ($str_encoding === false) {
+    $str_encoding = $DEFAULT_ENCODING;
+  }
+
+  // Converting encoding and returning updated string back
+  return mb_convert_encoding($str, $to_encoding, $str_encoding);
+}
+
 function packParamsJSON($params_array, $post_params)
 {
 
@@ -32,7 +62,7 @@ function utf8_converter($array)
 {
   array_walk_recursive($array, function (&$item, $key) {
     if ($item !== null && !mb_detect_encoding($item, 'utf-8', true)) {
-      $item = utf8_encode($item);
+      $item = encode_string($item);
     }
   });
 


### PR DESCRIPTION
The `search.php` file used [`utf8_encode`](https://www.php.net/manual/en/function.utf8-encode.php), which is considered deprecated since version 8.2 and may not correctly handle some characters in the strings. It is recommended to use [`mb_convert_encoding`](https://www.php.net/manual/en/function.mb-convert-encoding.php) to replace it. 

For this logic, a new separate function with documentation was created, which independently determines the encoding of the string to be converted to another format (previously, in `utf8_encode` the default encoding was [`ISO-8859-1`](https://en.wikipedia.org/wiki/ISO/IEC_8859-1) - not very flexible, the new approach is more universal, as it determines the original encoding itself using [`mb_detect_encoding`](https://www.php.net/manual/en/function.mb-detect-encoding.php) and the array with known encoding formats).