### PR TITLE
refactor: upgrade php to 8.2

### DIFF
--- a/local_dev/searchflow-container/Dockerfile
+++ b/local_dev/searchflow-container/Dockerfile
@@ -1,11 +1,11 @@
-FROM php:8.0-apache
+FROM php:8.2-apache
 
 LABEL maintainer="Chris Kittel <christopher.kittel@openknowledgemaps.org>"
 
 RUN a2enmod rewrite
 
 RUN apt-get update && apt-get install -y \
-    curl libsqlite3-dev php7.4-sqlite libonig-dev libxml2-dev \
+    curl libsqlite3-dev libonig-dev libxml2-dev \
     gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 \
     libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 \
     libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 \

--- a/server/classes/headstart/library/APIClient.php
+++ b/server/classes/headstart/library/APIClient.php
@@ -1,16 +1,22 @@
 <?php
 
 namespace headstart\library;
+
+use Exception;
+
 require_once dirname(__FILE__) . '/CommUtils.php';
 
 class APIClient {
+    private array $ini_array;
+    private string $database;
+    private string $base_route;
+    private array $settings;
 
     public function __construct($ini_array) {
-
         $this->load_configs($ini_array);
     }
 
-    public function load_configs($ini_array) {
+    public function load_configs(array $ini_array): void {
         $this->ini_array = $ini_array;
         $this->settings = $this->ini_array["general"];
         $this->database = $this->ini_array["connection"]["database"];
@@ -21,46 +27,44 @@ class APIClient {
 
     public function call_api($endpoint, $payload) {
         $route = $this->base_route . $endpoint;
+
         try {
             $res = CommUtils::call_api($route, $payload);
+
             if ($res["httpcode"] != 200) {
                 $res["route"] = $route;
                 $res = $this->handle_api_errors($res);
             }
+
             return $res;
         }
         catch (Exception $e) {
             error_log("Error in APIClient: " . $e);
-            $res = array("status"=>"error",
-                         "httpcode"=>500,
-                         "reason"=>array("unexpected data processing error"));
+            $res = array("status"=>"error", "httpcode"=>500, "reason"=>array("unexpected data processing error"));
             return $res;
         }
-        finally {
-        }        
     }
 
     public function call_persistence($endpoint, $payload) {
         $route = $this->base_route . "persistence/" . $endpoint . "/" . $this->database;
+
         try {
             $res = CommUtils::call_api($route, $payload);
+
             if ($res["httpcode"] != 200) {
                 $res["route"] = $route;
                 $res = $this->handle_api_errors($res);
             }
+
             return $res;
         }
         catch (Exception $e) {
             // what happens here is instead of bubbling the error up,
-            // it is caught and we fake a response that looks like an error
+            // fake a response that looks like an error
             // because of the hardcoded reason we loose the original error information
-            $res = array("status"=>"error",
-                         "httpcode"=>500,
-                         "reason"=>array("unexpected data processing error"));
+            $res = array("status"=>"error", "httpcode"=>500, "reason"=>array("unexpected data processing error"));
             return $res;
         }
-        finally {
-        }        
     }
 
     public function handle_api_errors($res) {
@@ -85,5 +89,4 @@ class APIClient {
         error_log(("Trying to handle API errors: " . print_r($res, true)));
         return $res;
     }
-
 }

--- a/server/services/getPDF.php
+++ b/server/services/getPDF.php
@@ -144,7 +144,7 @@ function extractValidPdfUrls(array $revision_data, string $paper_id, string $vis
 
     $inner_data = json_decode($revision_data["data"], true);
     $documents_raw = $inner_data["documents"] ?? null;
-    $documents = json_decode($documents_raw, true);
+    $documents = $documents_raw !== null ? json_decode($documents_raw, true) : null;
 
     if (strtolower($vis_type) == 'timeline') {
         $inner_data = json_decode($inner_data["data"]);

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -28,11 +28,35 @@ function packParamsJSON($params_array, $post_params)
   return json_encode($output_array);
 }
 
+function encode_string(string $str, string $to_encoding = 'UTF-8'): string {
+  // Defining constants with known encodings and default one
+  $DEFAULT_ENCODING = 'ISO-8859-1';
+  $ENCODINGS = [
+    'UTF-8',
+    'Windows-1251',
+    'ISO-8859-1',
+    'ASCII',
+    'KOI8-R',
+    'CP866'
+  ];
+
+  // Trying to define the received string encoding
+  $str_encoding = mb_detect_encoding($str, $ENCODINGS, true);
+
+  // If the received string encoding is unknown the default one will be used
+  if ($str_encoding === false) {
+    $str_encoding = $DEFAULT_ENCODING;
+  }
+
+  // Converting encoding and returning updated string back
+  return mb_convert_encoding($str, $to_encoding, $str_encoding);
+}
+
 function utf8_converter($array)
 {
   array_walk_recursive($array, function (&$item, $key) {
     if ($item !== null && !mb_detect_encoding($item, 'utf-8', true)) {
-      $item = utf8_encode($item);
+      $item = encode_string($item);
     }
   });
 

--- a/server/services/search.php
+++ b/server/services/search.php
@@ -31,7 +31,7 @@ function packParamsJSON($params_array, $post_params)
 function utf8_converter($array)
 {
   array_walk_recursive($array, function (&$item, $key) {
-    if (!mb_detect_encoding($item, 'utf-8', true)) {
+    if ($item !== null && !mb_detect_encoding($item, 'utf-8', true)) {
       $item = utf8_encode($item);
     }
   });


### PR DESCRIPTION
This PR contains changes related to the upgrade of PHP to version 8.2. 

List of changes:
- PHP version upgrade in the `Dockerfile`;
- `APIClient` class update related to the new syntax;
- Removed deprecated `utf8_encode` function.