### PR TITLE
feat: edge and opera in browser filtering

### DIFF
--- a/vis/js/HeadstartRunner.tsx
+++ b/vis/js/HeadstartRunner.tsx
@@ -86,7 +86,8 @@ class HeadstartRunner {
         "You are using an unsupported browser. " +
           "This visualization was successfully tested " +
           "with the latest versions of " +
-          "Chrome, Firefox, Safari, Edge and Opera."
+          "Chrome, Firefox, Safari, Edge and Opera. " +
+          "We strongly recommend using one of these browsers."
       );
     }
   }


### PR DESCRIPTION
This PR contains changes related to a method in the `HeadstartRunner` class that determines whether an end-user's browser is supported:
- Microsoft Edge and Opera have been added to the list of supported browsers;
- The message that appears in unsupported browsers was updated.