### PR TITLE
hotfix for log event which causes burst requests

### DIFF
--- a/vis/js/utils/actionLogger.ts
+++ b/vis/js/utils/actionLogger.ts
@@ -12,8 +12,8 @@ const logAction = (action: any, state: any) => {
   switch (action.type) {
     case "INITIALIZE":
       return trackMatomoEvent("Headstart", "Load");
-    case "RESIZE":
-      return trackMatomoEvent("Headstart", "Resize window");
+    // case "RESIZE":
+    //   return trackMatomoEvent("Headstart", "Resize window");
     case "SEARCH":
       // TODO trackSiteSearch ?
       // https://developer.matomo.org/guides/tracking-javascript-guide


### PR DESCRIPTION
This PR temporarily deactivates logging of browser resize events. These events current are not debounced and tend to create a large burst of logging requests.