### PR TITLE
bugfix for puppeteer process memory leak in snapshots

### DIFF
--- a/server/services/getChartSVG.js
+++ b/server/services/getChartSVG.js
@@ -1,4 +1,5 @@
 module.paths.push(process.argv[4]);
+const { time } = require('console');
 const puppeteer = require('puppeteer');
 
 function timeout(ms) {
@@ -6,8 +7,13 @@ function timeout(ms) {
 };
 
 (async() => {
+    let browser;
+    const watchdog = setTimeout(() => {
+        console.error('getChartSVG watchdog fired, exiting');
+        process.exit(1);
+    }, 60000); // 60 seconds
     try {
-        const browser = await puppeteer.launch({
+        browser = await puppeteer.launch({
             headless: true,
             args: ['--no-sandbox', '--disable-setuid-sandbox'],
             executablePath: process.argv[5]
@@ -16,12 +22,17 @@ function timeout(ms) {
         const page = await browser.newPage();
         await timeout(1000)
         await page.setViewport({width: 1920, height: 1080})
-        await page.goto(process.argv[2], {waitUntil: 'networkidle2'});
+        await page.goto(process.argv[2], {waitUntil: 'networkidle2', timeout: 60000});
         await timeout(1000)
         await page.screenshot({path: process.argv[3], clip: { x: 0, y: 0, width: 1150, height: 1080 }});
-        browser.close();
     } catch (error) {
         console.error('Error occurred while generating chart SVG:', error);
+        process.exitCode = 1;
+    } finally {
+        if (browser) {
+            try { await browser.close(); } catch (_) {}
+        }
+        clearTimeout(watchdog);
     }
 
 })();


### PR DESCRIPTION
browser declared outside try; await browser.close() in finally; explicit timeout on goto; a script-level watchdog so even a hung puppeteer can't live forever